### PR TITLE
Make `zone_id` optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ Available targets:
 | subnets | List of VPC subnet IDs | list | - | yes |
 | tags | Additional tags (e.g. map(`BusinessUnit`,`XYZ`) | map | `<map>` | no |
 | vpc_id | VPC ID to create the cluster in (e.g. `vpc-a22222ee`) | string | - | yes |
-| zone_id | Route53 parent zone ID. The module will create sub-domain DNS records in the parent zone for the DB master and replicas | string | - | yes |
+| zone_id | Route53 parent zone ID. If provided (not empty), the module will create sub-domain DNS records for the DB master and replicas | string | `` | no |
 
 ## Outputs
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -36,7 +36,7 @@
 | subnets | List of VPC subnet IDs | list | - | yes |
 | tags | Additional tags (e.g. map(`BusinessUnit`,`XYZ`) | map | `<map>` | no |
 | vpc_id | VPC ID to create the cluster in (e.g. `vpc-a22222ee`) | string | - | yes |
-| zone_id | Route53 parent zone ID. The module will create sub-domain DNS records in the parent zone for the DB master and replicas | string | - | yes |
+| zone_id | Route53 parent zone ID. If provided (not empty), the module will create sub-domain DNS records for the DB master and replicas | string | `` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -95,21 +95,21 @@ resource "aws_rds_cluster_parameter_group" "default" {
 }
 
 module "dns_master" {
-  source    = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=tags/0.2.2"
+  source    = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=tags/0.2.5"
   namespace = "${var.namespace}"
   name      = "master.${var.name}"
   stage     = "${var.stage}"
   zone_id   = "${var.zone_id}"
   records   = ["${coalescelist(aws_rds_cluster.default.*.endpoint, list(""))}"]
-  enabled   = "${var.enabled}"
+  enabled   = "${var.enabled == "true" && length(var.zone_id) > 0 ? "true" : "false"}"
 }
 
 module "dns_replicas" {
-  source    = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=tags/0.2.2"
+  source    = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=tags/0.2.5"
   namespace = "${var.namespace}"
   name      = "replicas.${var.name}"
   stage     = "${var.stage}"
   zone_id   = "${var.zone_id}"
   records   = ["${coalescelist(aws_rds_cluster.default.*.reader_endpoint, list(""))}"]
-  enabled   = "${var.enabled}"
+  enabled   = "${var.enabled == "true" && length(var.zone_id) > 0 ? "true" : "false"}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -15,7 +15,8 @@ variable "name" {
 
 variable "zone_id" {
   type        = "string"
-  description = "Route53 parent zone ID. The module will create sub-domain DNS records in the parent zone for the DB master and replicas"
+  default     = ""
+  description = "Route53 parent zone ID. If provided (not empty), the module will create sub-domain DNS records for the DB master and replicas"
 }
 
 variable "security_groups" {


### PR DESCRIPTION
## what
* Make `zone_id` optional

## why
* Not all applications require creating sub-domains for the DB master and replicas
* https://github.com/cloudposse/terraform-aws-rds-cluster/issues/29

