### PR TITLE
Remove invalid output parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,6 @@ Available targets:
   lint                                Lint terraform code
 
 ```
-
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -287,7 +286,6 @@ Available targets:
 | endpoint | The DNS address of the RDS instance |
 | master_host | DB Master hostname |
 | name | Database name |
-| password | Password for the master DB user |
 | reader_endpoint | A read-only endpoint for the Aurora cluster, automatically load-balanced across replicas |
 | replicas_host | Replicas hostname |
 | user | Username for the master DB user |
@@ -373,7 +371,7 @@ In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
 ## Copyright
 
-Copyright © 2017-2018 [Cloud Posse, LLC](https://cpco.io/copyright)
+Copyright © 2017-2019 [Cloud Posse, LLC](https://cpco.io/copyright)
 
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -1,4 +1,3 @@
-
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -49,7 +48,6 @@
 | endpoint | The DNS address of the RDS instance |
 | master_host | DB Master hostname |
 | name | Database name |
-| password | Password for the master DB user |
 | reader_endpoint | A read-only endpoint for the Aurora cluster, automatically load-balanced across replicas |
 | replicas_host | Replicas hostname |
 | user | Username for the master DB user |

--- a/outputs.tf
+++ b/outputs.tf
@@ -8,11 +8,6 @@ output "user" {
   description = "Username for the master DB user"
 }
 
-output "password" {
-  value       = "${join("", aws_rds_cluster.default.*.master_password)}"
-  description = "Password for the master DB user"
-}
-
 output "cluster_name" {
   value       = "${join("", aws_rds_cluster.default.*.cluster_identifier)}"
   description = "Cluster Identifier"


### PR DESCRIPTION
## what
* Remove `password` output

## why
* Not supported

```
* module.aurora_postgres.output.password: Resource 'aws_rds_cluster.default' does not have attribute 'master_password' for variable 'aws_rds_cluster.default.*.master_password'
```

## references
* https://www.terraform.io/docs/providers/aws/r/rds_cluster.html#attributes-reference