### PR TITLE
Add cluster autoscaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,8 +254,8 @@ Available targets:
 | autoscaling_policy_type | Autoscaling policy type. `TargetTrackingScaling` and `StepScaling` are supported | string | `TargetTrackingScaling` | no |
 | autoscaling_scale_in_cooldown | The amount of time, in seconds, after a scaling activity completes and before the next scaling down activity can start. Default is 300s | string | `300` | no |
 | autoscaling_scale_out_cooldown | The amount of time, in seconds, after a scaling activity completes and before the next scaling up activity can start. Default is 300s | string | `300` | no |
-| autoscaling_target_metrics | The metrics type to use with `autoscaling_policy_type`. If this value isn't provided the default is CPU utilization | string | `RDSReaderAverageCPUUtilization` | no |
-| autoscaling_target_value | The target value to scale up with resepect to target metrics | string | `75` | no |
+| autoscaling_target_metrics | The metrics type to use. If this value isn't provided the default is CPU utilization | string | `RDSReaderAverageCPUUtilization` | no |
+| autoscaling_target_value | The target value to scale with respect to target metrics | string | `75` | no |
 | backup_window | Daily time range during which the backups happen | string | `07:00-09:00` | no |
 | cluster_family | The family of the DB cluster parameter group | string | `aurora5.6` | no |
 | cluster_parameters | List of DB parameters to apply | list | `<list>` | no |

--- a/README.md
+++ b/README.md
@@ -248,6 +248,14 @@ Available targets:
 | allowed_cidr_blocks | List of CIDR blocks allowed to access | list | `<list>` | no |
 | apply_immediately | Specifies whether any cluster modifications are applied immediately, or during the next maintenance window | string | `true` | no |
 | attributes | Additional attributes (e.g. `1`) | list | `<list>` | no |
+| autoscaling_enabled | Whether to enable cluster autoscaling | string | `false` | no |
+| autoscaling_max_capacity | Maximum number of instances to be maintained by the autoscaler | string | `5` | no |
+| autoscaling_min_capacity | Minimum number of instances to be maintained by the autoscaler | string | `1` | no |
+| autoscaling_policy_type | Autoscaling policy type. `TargetTrackingScaling` and `StepScaling` are supported | string | `TargetTrackingScaling` | no |
+| autoscaling_scale_in_cooldown | The amount of time, in seconds, after a scaling activity completes and before the next scaling down activity can start. Default is 300s | string | `300` | no |
+| autoscaling_scale_out_cooldown | The amount of time, in seconds, after a scaling activity completes and before the next scaling up activity can start. Default is 300s | string | `300` | no |
+| autoscaling_target_metrics | The metrics type to use with `autoscaling_policy_type`. If this value isn't provided the default is CPU utilization | string | `RDSReaderAverageCPUUtilization` | no |
+| autoscaling_target_value | The target value to scale up with resepect to target metrics | string | `75` | no |
 | backup_window | Daily time range during which the backups happen | string | `07:00-09:00` | no |
 | cluster_family | The family of the DB cluster parameter group | string | `aurora5.6` | no |
 | cluster_parameters | List of DB parameters to apply | list | `<list>` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -7,6 +7,14 @@
 | allowed_cidr_blocks | List of CIDR blocks allowed to access | list | `<list>` | no |
 | apply_immediately | Specifies whether any cluster modifications are applied immediately, or during the next maintenance window | string | `true` | no |
 | attributes | Additional attributes (e.g. `1`) | list | `<list>` | no |
+| autoscaling_enabled | Whether to enable cluster autoscaling | string | `false` | no |
+| autoscaling_max_capacity | Maximum number of instances to be maintained by the autoscaler | string | `5` | no |
+| autoscaling_min_capacity | Minimum number of instances to be maintained by the autoscaler | string | `1` | no |
+| autoscaling_policy_type | Autoscaling policy type. `TargetTrackingScaling` and `StepScaling` are supported | string | `TargetTrackingScaling` | no |
+| autoscaling_scale_in_cooldown | The amount of time, in seconds, after a scaling activity completes and before the next scaling down activity can start. Default is 300s | string | `300` | no |
+| autoscaling_scale_out_cooldown | The amount of time, in seconds, after a scaling activity completes and before the next scaling up activity can start. Default is 300s | string | `300` | no |
+| autoscaling_target_metrics | The metrics type to use with `autoscaling_policy_type`. If this value isn't provided the default is CPU utilization | string | `RDSReaderAverageCPUUtilization` | no |
+| autoscaling_target_value | The target value to scale up with resepect to target metrics | string | `75` | no |
 | backup_window | Daily time range during which the backups happen | string | `07:00-09:00` | no |
 | cluster_family | The family of the DB cluster parameter group | string | `aurora5.6` | no |
 | cluster_parameters | List of DB parameters to apply | list | `<list>` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -13,8 +13,8 @@
 | autoscaling_policy_type | Autoscaling policy type. `TargetTrackingScaling` and `StepScaling` are supported | string | `TargetTrackingScaling` | no |
 | autoscaling_scale_in_cooldown | The amount of time, in seconds, after a scaling activity completes and before the next scaling down activity can start. Default is 300s | string | `300` | no |
 | autoscaling_scale_out_cooldown | The amount of time, in seconds, after a scaling activity completes and before the next scaling up activity can start. Default is 300s | string | `300` | no |
-| autoscaling_target_metrics | The metrics type to use with `autoscaling_policy_type`. If this value isn't provided the default is CPU utilization | string | `RDSReaderAverageCPUUtilization` | no |
-| autoscaling_target_value | The target value to scale up with resepect to target metrics | string | `75` | no |
+| autoscaling_target_metrics | The metrics type to use. If this value isn't provided the default is CPU utilization | string | `RDSReaderAverageCPUUtilization` | no |
+| autoscaling_target_value | The target value to scale with respect to target metrics | string | `75` | no |
 | backup_window | Daily time range during which the backups happen | string | `07:00-09:00` | no |
 | cluster_family | The family of the DB cluster parameter group | string | `aurora5.6` | no |
 | cluster_parameters | List of DB parameters to apply | list | `<list>` | no |

--- a/main.tf
+++ b/main.tf
@@ -65,10 +65,16 @@ resource "aws_rds_cluster" "default" {
   replication_source_identifier       = "${var.replication_source_identifier}"
 }
 
+locals {
+  # If cluster is disabled, set the count to zero
+  # Otherwise, if autoscaling is enabled, set the instance count to `1`. If auto-scaling is disabled, use `var.cluster_size`
+  cluster_instance_count = "${var.enabled == "true" ? (var.autoscaling_enabled == "true" ? 1 : var.cluster_size) : 0}"
+}
+
 resource "aws_rds_cluster_instance" "default" {
-  count                           = "${var.enabled == "true" ? var.cluster_size : 0}"
+  count                           = "${local.cluster_instance_count}"
   identifier                      = "${module.label.id}-${count.index+1}"
-  cluster_identifier              = "${aws_rds_cluster.default.id}"
+  cluster_identifier              = "${join("", aws_rds_cluster.default.*.id)}"
   instance_class                  = "${var.instance_type}"
   db_subnet_group_name            = "${aws_db_subnet_group.default.name}"
   db_parameter_group_name         = "${aws_db_parameter_group.default.name}"
@@ -126,4 +132,32 @@ module "dns_replicas" {
   zone_id   = "${var.zone_id}"
   records   = ["${coalescelist(aws_rds_cluster.default.*.reader_endpoint, list(""))}"]
   enabled   = "${var.enabled == "true" && length(var.zone_id) > 0 ? "true" : "false"}"
+}
+
+resource "aws_appautoscaling_target" "replicas" {
+  count              = "${var.autoscaling_enabled == "true" ? 1 : 0}"
+  service_namespace  = "rds"
+  scalable_dimension = "rds:cluster:ReadReplicaCount"
+  resource_id        = "cluster:${aws_rds_cluster.default.id}"
+  min_capacity       = "${var.autoscaling_min_capacity}"
+  max_capacity       = "${var.autoscaling_max_capacity}"
+}
+
+resource "aws_appautoscaling_policy" "replicas" {
+  count              = "${var.autoscaling_enabled == "true" ? 1 : 0}"
+  name               = "${module.label.id}"
+  service_namespace  = "${join("", aws_appautoscaling_target.replicas.*.service_namespace)}"
+  scalable_dimension = "${join("", aws_appautoscaling_target.replicas.*.scalable_dimension)}"
+  resource_id        = "${join("", aws_appautoscaling_target.replicas.*.resource_id)}"
+  policy_type        = "${var.autoscaling_policy_type}"
+
+  target_tracking_scaling_policy_configuration {
+    predefined_metric_specification {
+      predefined_metric_type = "${var.autoscaling_target_metrics}"
+    }
+
+    target_value       = "${var.autoscaling_target_value}"
+    scale_in_cooldown  = "${var.autoscaling_scale_in_cooldown}"
+    scale_out_cooldown = "${var.autoscaling_scale_out_cooldown}"
+  }
 }

--- a/main.tf
+++ b/main.tf
@@ -66,9 +66,8 @@ resource "aws_rds_cluster" "default" {
 }
 
 locals {
-  # If cluster is disabled, set the count to zero
-  # Otherwise, if autoscaling is enabled, set the instance count to `var.autoscaling_min_capacity`. If autoscaling is disabled, use `var.cluster_size`
-  cluster_instance_count = "${var.enabled == "true" ? (var.autoscaling_enabled == "true" ? var.autoscaling_min_capacity : var.cluster_size) : 0}"
+  min_instance_count     = "${var.autoscaling_enabled == "true" ? var.autoscaling_min_capacity : var.cluster_size}"
+  cluster_instance_count = "${var.enabled == "true" ? local.min_instance_count : 0}"
 }
 
 resource "aws_rds_cluster_instance" "default" {
@@ -156,6 +155,7 @@ resource "aws_appautoscaling_policy" "replicas" {
       predefined_metric_type = "${var.autoscaling_target_metrics}"
     }
 
+    disable_scale_in   = false
     target_value       = "${var.autoscaling_target_value}"
     scale_in_cooldown  = "${var.autoscaling_scale_in_cooldown}"
     scale_out_cooldown = "${var.autoscaling_scale_out_cooldown}"

--- a/main.tf
+++ b/main.tf
@@ -67,8 +67,8 @@ resource "aws_rds_cluster" "default" {
 
 locals {
   # If cluster is disabled, set the count to zero
-  # Otherwise, if autoscaling is enabled, set the instance count to `1`. If auto-scaling is disabled, use `var.cluster_size`
-  cluster_instance_count = "${var.enabled == "true" ? (var.autoscaling_enabled == "true" ? 1 : var.cluster_size) : 0}"
+  # Otherwise, if autoscaling is enabled, set the instance count to `var.autoscaling_min_capacity`. If autoscaling is disabled, use `var.cluster_size`
+  cluster_instance_count = "${var.enabled == "true" ? (var.autoscaling_enabled == "true" ? var.autoscaling_min_capacity : var.cluster_size) : 0}"
 }
 
 resource "aws_rds_cluster_instance" "default" {

--- a/main.tf
+++ b/main.tf
@@ -134,7 +134,7 @@ module "dns_replicas" {
 }
 
 resource "aws_appautoscaling_target" "replicas" {
-  count              = "${var.autoscaling_enabled == "true" ? 1 : 0}"
+  count              = "${var.enabled == "true" && var.autoscaling_enabled == "true" ? 1 : 0}"
   service_namespace  = "rds"
   scalable_dimension = "rds:cluster:ReadReplicaCount"
   resource_id        = "cluster:${aws_rds_cluster.default.id}"
@@ -143,7 +143,7 @@ resource "aws_appautoscaling_target" "replicas" {
 }
 
 resource "aws_appautoscaling_policy" "replicas" {
-  count              = "${var.autoscaling_enabled == "true" ? 1 : 0}"
+  count              = "${var.enabled == "true" && var.autoscaling_enabled == "true" ? 1 : 0}"
   name               = "${module.label.id}"
   service_namespace  = "${join("", aws_appautoscaling_target.replicas.*.service_namespace)}"
   scalable_dimension = "${join("", aws_appautoscaling_target.replicas.*.scalable_dimension)}"

--- a/variables.tf
+++ b/variables.tf
@@ -218,3 +218,49 @@ variable "performance_insights_kms_key_id" {
   default     = ""
   description = "The ARN for the KMS key to encrypt Performance Insights data. When specifying `performance_insights_kms_key_id`, `performance_insights_enabled` needs to be set to true"
 }
+
+variable "autoscaling_enabled" {
+  type        = "string"
+  default     = "false"
+  description = "Whether to enable cluster autoscaling"
+}
+
+variable "autoscaling_policy_type" {
+  type        = "string"
+  default     = "TargetTrackingScaling"
+  description = "Autoscaling policy type. `TargetTrackingScaling` and `StepScaling` are supported"
+}
+
+variable "autoscaling_target_metrics" {
+  type        = "string"
+  default     = "RDSReaderAverageCPUUtilization"
+  description = "The metrics type to use with `autoscaling_policy_type`. If this value isn't provided the default is CPU utilization"
+}
+
+variable "autoscaling_target_value" {
+  type        = "string"
+  default     = "75"
+  description = "The target value to scale up with resepect to target metrics"
+}
+
+variable "autoscaling_scale_in_cooldown" {
+  type        = "string"
+  default     = "300"
+  description = "The amount of time, in seconds, after a scaling activity completes and before the next scaling down activity can start. Default is 300s"
+}
+
+variable "autoscaling_scale_out_cooldown" {
+  type        = "string"
+  default     = "300"
+  description = "The amount of time, in seconds, after a scaling activity completes and before the next scaling up activity can start. Default is 300s"
+}
+
+variable "autoscaling_min_capacity" {
+  default     = 1
+  description = "Minimum number of instances to be maintained by the autoscaler"
+}
+
+variable "autoscaling_max_capacity" {
+  default     = 5
+  description = "Maximum number of instances to be maintained by the autoscaler"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -234,24 +234,21 @@ variable "autoscaling_policy_type" {
 variable "autoscaling_target_metrics" {
   type        = "string"
   default     = "RDSReaderAverageCPUUtilization"
-  description = "The metrics type to use with `autoscaling_policy_type`. If this value isn't provided the default is CPU utilization"
+  description = "The metrics type to use. If this value isn't provided the default is CPU utilization"
 }
 
 variable "autoscaling_target_value" {
-  type        = "string"
-  default     = "75"
-  description = "The target value to scale up with resepect to target metrics"
+  default     = 75
+  description = "The target value to scale with respect to target metrics"
 }
 
 variable "autoscaling_scale_in_cooldown" {
-  type        = "string"
-  default     = "300"
+  default     = 300
   description = "The amount of time, in seconds, after a scaling activity completes and before the next scaling down activity can start. Default is 300s"
 }
 
 variable "autoscaling_scale_out_cooldown" {
-  type        = "string"
-  default     = "300"
+  default     = 300
   description = "The amount of time, in seconds, after a scaling activity completes and before the next scaling up activity can start. Default is 300s"
 }
 


### PR DESCRIPTION
## what
* Add Aurora cluster [autoscaling](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Aurora.Integrating.AutoScaling.html)

## why
* To be able to scale the read replica count up/down depending on cluster utilization
