### PR TITLE
Remove `password` output

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,6 @@ Available targets:
 | endpoint | The DNS address of the RDS instance |
 | master_host | DB Master hostname |
 | name | Database name |
-| password | Password for the master DB user |
 | reader_endpoint | A read-only endpoint for the Aurora cluster, automatically load-balanced across replicas |
 | replicas_host | Replicas hostname |
 | user | Username for the master DB user |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -59,7 +59,6 @@
 | endpoint | The DNS address of the RDS instance |
 | master_host | DB Master hostname |
 | name | Database name |
-| password | Password for the master DB user |
 | reader_endpoint | A read-only endpoint for the Aurora cluster, automatically load-balanced across replicas |
 | replicas_host | Replicas hostname |
 | user | Username for the master DB user |

--- a/examples/basic/outputs.tf
+++ b/examples/basic/outputs.tf
@@ -8,11 +8,6 @@ output "user" {
   description = "Username for the master DB user"
 }
 
-output "password" {
-  value       = "${module.rds_cluster_aurora_postgres.password}"
-  description = "Password for the master DB user"
-}
-
 output "cluster_name" {
   value       = "${module.rds_cluster_aurora_postgres.cluster_name}"
   description = "Cluster Identifier"

--- a/examples/enhanced_monitoring/outputs.tf
+++ b/examples/enhanced_monitoring/outputs.tf
@@ -8,11 +8,6 @@ output "user" {
   description = "Username for the master DB user"
 }
 
-output "password" {
-  value       = "${module.rds_cluster_aurora_postgres.password}"
-  description = "Password for the master DB user"
-}
-
 output "cluster_name" {
   value       = "${module.rds_cluster_aurora_postgres.cluster_name}"
   description = "Cluster Identifier"

--- a/examples/serverless_mysql/outputs.tf
+++ b/examples/serverless_mysql/outputs.tf
@@ -8,11 +8,6 @@ output "user" {
   description = "Username for the master DB user"
 }
 
-output "password" {
-  value       = "${module.rds_cluster_aurora_mysql_serverless.password}"
-  description = "Password for the master DB user"
-}
-
 output "cluster_name" {
   value       = "${module.rds_cluster_aurora_mysql_serverless.cluster_name}"
   description = "Cluster Identifier"

--- a/examples/with_cluster_parameters/outputs.tf
+++ b/examples/with_cluster_parameters/outputs.tf
@@ -8,11 +8,6 @@ output "user" {
   description = "Username for the master DB user"
 }
 
-output "password" {
-  value       = "${module.rds_cluster_aurora_mysql.password}"
-  description = "Password for the master DB user"
-}
-
 output "cluster_name" {
   value       = "${module.rds_cluster_aurora_mysql.cluster_name}"
   description = "Cluster Identifier"

--- a/outputs.tf
+++ b/outputs.tf
@@ -8,11 +8,6 @@ output "user" {
   description = "Username for the master DB user"
 }
 
-output "password" {
-  value       = "${join("", aws_rds_cluster.default.*.master_password)}"
-  description = "Password for the master DB user"
-}
-
 output "cluster_name" {
   value       = "${join("", aws_rds_cluster.default.*.cluster_identifier)}"
   description = "Cluster Identifier"


### PR DESCRIPTION
## what
* Remove `password` output

## why
* No longer supported by Terraform `aws_rds_cluster`

```
Error: Error running plan: 1 error(s) occurred:

* module.aurora_postgres.output.password: Resource 'aws_rds_cluster.default' does not have attribute 'master_password' for variable 'aws_rds_cluster.default.*.master_password'
```

* Better for security
