### PR TITLE
Add cluster and reader DNS names

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,10 @@ We literally have [*hundreds of terraform modules*][terraform_modules] that are 
 ## Usage
 
 
-**IMPORTANT:** The `master` branch is used in `source` just as an example. In your code, do not pin to `master` because there may be breaking changes between releases. Instead pin to the release tag (e.g. `?ref=tags/x.y.z`) of one of our [latest releases](https://github.com/cloudposse/terraform-aws-rds-cluster/releases).
+**IMPORTANT:** The `master` branch is used in `source` just as an example. In your code, do not pin to `master` because there may be breaking changes between releases.
+Instead pin to the release tag (e.g. `?ref=tags/x.y.z`) of one of our [latest releases](https://github.com/cloudposse/terraform-aws-rds-cluster/releases).
+
+
 
 [Basic example](examples/basic)
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ We literally have [*hundreds of terraform modules*][terraform_modules] that are 
 ## Usage
 
 
-**IMPORTANT:** Do not pin to `master` because there may be breaking changes between releases. Instead pin to the release tag (e.g. `?ref=tags/x.y.z`) of one of our [latest releases](https://github.com/cloudposse/terraform-aws-rds-cluster/releases).
+**IMPORTANT:** The `master` branch is used in `source` just as an example. In your code, do not pin to `master` because there may be breaking changes between releases. Instead pin to the release tag (e.g. `?ref=tags/x.y.z`) of one of our [latest releases](https://github.com/cloudposse/terraform-aws-rds-cluster/releases).
 
 [Basic example](examples/basic)
 
@@ -257,6 +257,7 @@ Available targets:
 | autoscaling_target_metrics | The metrics type to use. If this value isn't provided the default is CPU utilization | string | `RDSReaderAverageCPUUtilization` | no |
 | autoscaling_target_value | The target value to scale with respect to target metrics | string | `75` | no |
 | backup_window | Daily time range during which the backups happen | string | `07:00-09:00` | no |
+| cluster_dns_name | Name of the cluster CNAME record to create in the parent DNS zone specified by `zone_id`. If left empty, the name will be auto-asigned using the format `master.var.name` | string | `` | no |
 | cluster_family | The family of the DB cluster parameter group | string | `aurora5.6` | no |
 | cluster_parameters | List of DB parameters to apply | list | `<list>` | no |
 | cluster_size | Number of DB instances to create in the cluster | string | `2` | no |
@@ -282,6 +283,7 @@ Available targets:
 | publicly_accessible | Set to true if you want your cluster to be publicly accessible (such as via QuickSight) | string | `false` | no |
 | rds_monitoring_interval | Interval in seconds that metrics are collected, 0 to disable (values can only be 0, 1, 5, 10, 15, 30, 60) | string | `0` | no |
 | rds_monitoring_role_arn | The ARN for the IAM role that can send monitoring metrics to CloudWatch Logs | string | `` | no |
+| reader_dns_name | Name of the reader endpoint CNAME record to create in the parent DNS zone specified by `zone_id`. If left empty, the name will be auto-asigned using the format `replicas.var.name` | string | `` | no |
 | replication_source_identifier | ARN of a source DB cluster or DB instance if this DB cluster is to be created as a Read Replica | string | `` | no |
 | retention_period | Number of days to retain backups for | string | `5` | no |
 | scaling_configuration | List of nested attributes with scaling properties. Only valid when engine_mode is set to `serverless` | list | `<list>` | no |

--- a/README.yaml
+++ b/README.yaml
@@ -61,8 +61,6 @@ description: |-
 # How to use this project
 usage: |-
 
-  **IMPORTANT:** The `master` branch is used in `source` just as an example. In your code, do not pin to `master` because there may be breaking changes between releases. Instead pin to the release tag (e.g. `?ref=tags/x.y.z`) of one of our [latest releases](https://github.com/cloudposse/terraform-aws-rds-cluster/releases).
-
   [Basic example](examples/basic)
 
   ```hcl

--- a/README.yaml
+++ b/README.yaml
@@ -61,7 +61,7 @@ description: |-
 # How to use this project
 usage: |-
 
-  **IMPORTANT:** Do not pin to `master` because there may be breaking changes between releases. Instead pin to the release tag (e.g. `?ref=tags/x.y.z`) of one of our [latest releases](https://github.com/cloudposse/terraform-aws-rds-cluster/releases).
+  **IMPORTANT:** The `master` branch is used in `source` just as an example. In your code, do not pin to `master` because there may be breaking changes between releases. Instead pin to the release tag (e.g. `?ref=tags/x.y.z`) of one of our [latest releases](https://github.com/cloudposse/terraform-aws-rds-cluster/releases).
 
   [Basic example](examples/basic)
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -16,6 +16,7 @@
 | autoscaling_target_metrics | The metrics type to use. If this value isn't provided the default is CPU utilization | string | `RDSReaderAverageCPUUtilization` | no |
 | autoscaling_target_value | The target value to scale with respect to target metrics | string | `75` | no |
 | backup_window | Daily time range during which the backups happen | string | `07:00-09:00` | no |
+| cluster_dns_name | Name of the cluster CNAME record to create in the parent DNS zone specified by `zone_id`. If left empty, the name will be auto-asigned using the format `master.var.name` | string | `` | no |
 | cluster_family | The family of the DB cluster parameter group | string | `aurora5.6` | no |
 | cluster_parameters | List of DB parameters to apply | list | `<list>` | no |
 | cluster_size | Number of DB instances to create in the cluster | string | `2` | no |
@@ -41,6 +42,7 @@
 | publicly_accessible | Set to true if you want your cluster to be publicly accessible (such as via QuickSight) | string | `false` | no |
 | rds_monitoring_interval | Interval in seconds that metrics are collected, 0 to disable (values can only be 0, 1, 5, 10, 15, 30, 60) | string | `0` | no |
 | rds_monitoring_role_arn | The ARN for the IAM role that can send monitoring metrics to CloudWatch Logs | string | `` | no |
+| reader_dns_name | Name of the reader endpoint CNAME record to create in the parent DNS zone specified by `zone_id`. If left empty, the name will be auto-asigned using the format `replicas.var.name` | string | `` | no |
 | replication_source_identifier | ARN of a source DB cluster or DB instance if this DB cluster is to be created as a Read Replica | string | `` | no |
 | retention_period | Number of days to retain backups for | string | `5` | no |
 | scaling_configuration | List of nested attributes with scaling properties. Only valid when engine_mode is set to `serverless` | list | `<list>` | no |

--- a/main.tf
+++ b/main.tf
@@ -117,24 +117,31 @@ resource "aws_db_parameter_group" "default" {
   tags        = "${module.label.tags}"
 }
 
+locals {
+  cluster_dns_name_default = "master.${var.name}"
+  cluster_dns_name         = "${var.cluster_dns_name != "" ? var.cluster_dns_name : local.cluster_dns_name_default}"
+  reader_dns_name_default  = "replicas.${var.name}"
+  reader_dns_name          = "${var.reader_dns_name != "" ? var.reader_dns_name : local.reader_dns_name_default}"
+}
+
 module "dns_master" {
-  source    = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=tags/0.2.5"
+  source    = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=tags/0.2.6"
+  enabled   = "${var.enabled == "true" && length(var.zone_id) > 0 ? "true" : "false"}"
   namespace = "${var.namespace}"
-  name      = "master.${var.name}"
+  name      = "${local.cluster_dns_name}"
   stage     = "${var.stage}"
   zone_id   = "${var.zone_id}"
   records   = ["${coalescelist(aws_rds_cluster.default.*.endpoint, list(""))}"]
-  enabled   = "${var.enabled == "true" && length(var.zone_id) > 0 ? "true" : "false"}"
 }
 
 module "dns_replicas" {
-  source    = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=tags/0.2.5"
+  source    = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=tags/0.2.6"
+  enabled   = "${var.enabled == "true" && length(var.zone_id) > 0 ? "true" : "false"}"
   namespace = "${var.namespace}"
-  name      = "replicas.${var.name}"
+  name      = "${local.reader_dns_name}"
   stage     = "${var.stage}"
   zone_id   = "${var.zone_id}"
   records   = ["${coalescelist(aws_rds_cluster.default.*.reader_endpoint, list(""))}"]
-  enabled   = "${var.enabled == "true" && length(var.zone_id) > 0 ? "true" : "false"}"
 }
 
 resource "aws_appautoscaling_target" "replicas" {

--- a/variables.tf
+++ b/variables.tf
@@ -283,3 +283,15 @@ variable "instance_availability_zone" {
   default     = ""
   description = "Optional parameter to place cluster instances in a specific availability zone. If left empty, will place randomly"
 }
+
+variable "cluster_dns_name" {
+  type        = "string"
+  description = "Name of the cluster CNAME record to create in the parent DNS zone specified by `zone_id`. If left empty, the name will be auto-asigned using the format `master.var.name`"
+  default     = ""
+}
+
+variable "reader_dns_name" {
+  type        = "string"
+  description = "Name of the reader endpoint CNAME record to create in the parent DNS zone specified by `zone_id`. If left empty, the name will be auto-asigned using the format `replicas.var.name`"
+  default     = ""
+}


### PR DESCRIPTION
## what
* Add cluster and reader DNS names

## why
* The default DNS names can conflict with other database clusters when deployed together (e.g. DocumentDB for Codefresh on-prem)

