### PR TITLE
provision dns replicas if engine is not serverless

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -142,6 +142,7 @@ module "dns_replicas" {
   stage     = "${var.stage}"
   zone_id   = "${var.zone_id}"
   records   = ["${coalescelist(aws_rds_cluster.default.*.reader_endpoint, list(""))}"]
+  enabled   = "${var.enabled == "true" && var.engine_mode != "serverless" ? "true" : "false"}"
 }
 
 resource "aws_appautoscaling_target" "replicas" {

--- a/main.tf
+++ b/main.tf
@@ -142,7 +142,7 @@ module "dns_replicas" {
   stage     = "${var.stage}"
   zone_id   = "${var.zone_id}"
   records   = ["${coalescelist(aws_rds_cluster.default.*.reader_endpoint, list(""))}"]
-  enabled   = "${var.enabled == "true" && var.engine_mode != "serverless" ? "true" : "false"}"
+  enabled   = "${var.enabled == "true" && length(var.zone_id) > 0 && var.engine_mode != "serverless" ? "true" : "false"}"
 }
 
 resource "aws_appautoscaling_target" "replicas" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -47,3 +47,8 @@ output "cluster_resource_id" {
   value       = "${join("", aws_rds_cluster.default.*.cluster_resource_id )}"
   description = "The region-unique, immutable identifie of the cluster."
 }
+
+output "cluster_security_groups" {
+  description = "Default RDS cluster security group"
+  value       = ["${aws_rds_cluster.default.*.vpc_security_group_ids}"]
+}


### PR DESCRIPTION
serverless instances like MySQL Aurora Serverless don't have reader endpoints. This causes errors with R53 when provisioning using this module because an empty replica endpoint is trying to be inserted.

I added a check that if engine_mode is not serverless, then provision DNS records