### PR TITLE
fix: respect timeout_action from scaling_configuration

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -75,6 +75,7 @@ resource "aws_rds_cluster" "default" {
       max_capacity             = lookup(scaling_configuration.value, "max_capacity", null)
       min_capacity             = lookup(scaling_configuration.value, "min_capacity", null)
       seconds_until_auto_pause = lookup(scaling_configuration.value, "seconds_until_auto_pause", null)
+      timeout_action           = lookup(scaling_configuration.value, "timeout_action", null)
     }
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -177,6 +177,7 @@ variable "scaling_configuration" {
     max_capacity             = number
     min_capacity             = number
     seconds_until_auto_pause = number
+    timeout_action           = string
   }))
   default     = []
   description = "List of nested attributes with scaling properties. Only valid when `engine_mode` is set to `serverless`"


### PR DESCRIPTION
`timeout_action` isn't passed through to the `aws_rds_cluster` resource when specified at the module level. This PR will fix that.