### PR TITLE
Allow setting `copy_tags_to_snapshot` variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,7 @@ Available targets:
 | cluster_family | The family of the DB cluster parameter group | string | `aurora5.6` | no |
 | cluster_parameters | List of DB cluster parameters to apply | object | `<list>` | no |
 | cluster_size | Number of DB instances to create in the cluster | number | `2` | no |
+| copy_tags_to_snapshot | Copy tags to backup snapshots | bool | `false` | no |
 | db_name | Database name | string | - | yes |
 | db_port | Database port | number | `3306` | no |
 | deletion_protection | If the DB instance should have deletion protection enabled | bool | `false` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -21,6 +21,7 @@
 | cluster_family | The family of the DB cluster parameter group | string | `aurora5.6` | no |
 | cluster_parameters | List of DB cluster parameters to apply | object | `<list>` | no |
 | cluster_size | Number of DB instances to create in the cluster | number | `2` | no |
+| copy_tags_to_snapshot | Copy tags to backup snapshots | bool | `false` | no |
 | db_name | Database name | string | - | yes |
 | db_port | Database port | number | `3306` | no |
 | deletion_protection | If the DB instance should have deletion protection enabled | bool | `false` | no |

--- a/main.tf
+++ b/main.tf
@@ -48,6 +48,7 @@ resource "aws_rds_cluster" "default" {
   master_password                     = var.admin_password
   backup_retention_period             = var.retention_period
   preferred_backup_window             = var.backup_window
+  copy_tags_to_snapshot               = var.copy_tags_to_snapshot
   final_snapshot_identifier           = lower(module.label.id)
   skip_final_snapshot                 = var.skip_final_snapshot
   apply_immediately                   = var.apply_immediately

--- a/variables.tf
+++ b/variables.tf
@@ -213,6 +213,12 @@ variable "skip_final_snapshot" {
   default     = true
 }
 
+variable "copy_tags_to_snapshot" {
+  type        = bool
+  description = "Copy tags to backup snapshots"
+  default     = false
+}
+
 variable "deletion_protection" {
   type        = bool
   description = "If the DB instance should have deletion protection enabled"


### PR DESCRIPTION
Allow copy_tags_to_snapshot to be set to true via terraform.

Signed-off-by: Jon Whitcraft <jwhitcraft@mac.com>