### PR TITLE
Allow creation of a cluster without creation of a database

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ Available targets:
 | cluster_parameters | List of DB cluster parameters to apply | object | `<list>` | no |
 | cluster_size | Number of DB instances to create in the cluster | number | `2` | no |
 | copy_tags_to_snapshot | Copy tags to backup snapshots | bool | `false` | no |
-| db_name | Database name | string | - | yes |
+| db_name | Database name (default is not to create a database) | string | `` | no |
 | db_port | Database port | number | `3306` | no |
 | deletion_protection | If the DB instance should have deletion protection enabled | bool | `false` | no |
 | delimiter | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes` | string | `-` | no |
@@ -313,7 +313,7 @@ Available targets:
 | enabled_cloudwatch_logs_exports | List of log types to export to cloudwatch. The following log types are supported: audit, error, general, slowquery | list(string) | `<list>` | no |
 | engine | The name of the database engine to be used for this DB cluster. Valid values: `aurora`, `aurora-mysql`, `aurora-postgresql` | string | `aurora` | no |
 | engine_mode | The database engine mode. Valid values: `parallelquery`, `provisioned`, `serverless` | string | `provisioned` | no |
-| engine_version | The version number of the database engine to use | string | `` | no |
+| engine_version | The version of the database engine to use. See `aws rds describe-db-engine-versions` | string | `` | no |
 | environment | Environment, e.g. 'prod', 'staging', 'dev', 'pre-prod', 'UAT' | string | `` | no |
 | global_cluster_identifier | ID of the Aurora global cluster | string | `` | no |
 | iam_database_authentication_enabled | Specifies whether or mappings of AWS Identity and Access Management (IAM) accounts to database accounts is enabled | bool | `false` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -22,7 +22,7 @@
 | cluster_parameters | List of DB cluster parameters to apply | object | `<list>` | no |
 | cluster_size | Number of DB instances to create in the cluster | number | `2` | no |
 | copy_tags_to_snapshot | Copy tags to backup snapshots | bool | `false` | no |
-| db_name | Database name | string | - | yes |
+| db_name | Database name (default is not to create a database) | string | `` | no |
 | db_port | Database port | number | `3306` | no |
 | deletion_protection | If the DB instance should have deletion protection enabled | bool | `false` | no |
 | delimiter | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes` | string | `-` | no |
@@ -30,7 +30,7 @@
 | enabled_cloudwatch_logs_exports | List of log types to export to cloudwatch. The following log types are supported: audit, error, general, slowquery | list(string) | `<list>` | no |
 | engine | The name of the database engine to be used for this DB cluster. Valid values: `aurora`, `aurora-mysql`, `aurora-postgresql` | string | `aurora` | no |
 | engine_mode | The database engine mode. Valid values: `parallelquery`, `provisioned`, `serverless` | string | `provisioned` | no |
-| engine_version | The version number of the database engine to use | string | `` | no |
+| engine_version | The version of the database engine to use. See `aws rds describe-db-engine-versions` | string | `` | no |
 | environment | Environment, e.g. 'prod', 'staging', 'dev', 'pre-prod', 'UAT' | string | `` | no |
 | global_cluster_identifier | ID of the Aurora global cluster | string | `` | no |
 | iam_database_authentication_enabled | Specifies whether or mappings of AWS Identity and Access Management (IAM) accounts to database accounts is enabled | bool | `false` | no |

--- a/examples/complete/fixtures.us-west-1.tfvars
+++ b/examples/complete/fixtures.us-west-1.tfvars
@@ -8,7 +8,7 @@ stage = "test"
 
 name = "rds-cluster"
 
-instance_type = "db.t2.small"
+instance_type = "db.t3.small"
 
 cluster_family = "aurora5.6"
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,5 +1,5 @@
 output "database_name" {
-  value       = join("", aws_rds_cluster.default.*.database_name)
+  value       = var.db_name
   description = "Database name"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -88,7 +88,8 @@ variable "snapshot_identifier" {
 
 variable "db_name" {
   type        = string
-  description = "Database name"
+  default = ""
+  description = "Database name (default is not to create a database)"
 }
 
 variable "db_port" {
@@ -168,7 +169,7 @@ variable "engine_mode" {
 variable "engine_version" {
   type        = string
   default     = ""
-  description = "The version number of the database engine to use"
+  description = "The version of the database engine to use. See `aws rds describe-db-engine-versions` "
 }
 
 variable "scaling_configuration" {

--- a/variables.tf
+++ b/variables.tf
@@ -88,7 +88,7 @@ variable "snapshot_identifier" {
 
 variable "db_name" {
   type        = string
-  default = ""
+  default     = ""
   description = "Database name (default is not to create a database)"
 }
 


### PR DESCRIPTION
## what

Allow creation of a cluster without creation of a database

## why

It is possible and acceptable to create a cluster first and add database(s) and user(s) later, but this module did not allow it before now