### PR TITLE
fix(#63): instance_count to be independent of autoscaling_min_capacity

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -95,8 +95,7 @@ resource "aws_rds_cluster" "default" {
 }
 
 locals {
-  min_instance_count     = var.autoscaling_enabled ? var.autoscaling_min_capacity : var.cluster_size
-  cluster_instance_count = var.enabled ? local.min_instance_count : 0
+  cluster_instance_count = var.enabled ? var.cluster_size : 0
 }
 
 resource "aws_rds_cluster_instance" "default" {


### PR DESCRIPTION
Fix for https://github.com/cloudposse/terraform-aws-rds-cluster/issues/63

The cluster_size or the instance_count should be independent of autoscaling_min_capacity as autoscaling_min_capacity is automatically taken care of by AWS through the autoscaling policy.

For example, when autoscaling is enabled:

if I specify:
```
    cluster_size = 2
    autoscaling_min_capacity = 1
```
  
  terraform creates only one instance even though cluster_size is set to 2 , 

  and if I specify:
```
    cluster_size = 2
    autoscaling_min_capacity = 2 
```

  terraform spins up 2 instances but AWS autoscaling policy immediately spins up one more instance, which is not desired. 

  This also breaks the terraform as it is not aware of the new instance that is created by AWS autoscaling policy. 
    