### PR TITLE
feat(enable_http_endpoint): added new enable_http_endpoint option for aurora serverless engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,23 +117,23 @@ module "rds_cluster_aurora_postgres" {
 
 ```hcl
 module "rds_cluster_aurora_mysql_serverless" {
-  source               = "git::https://github.com/cloudposse/terraform-aws-rds-cluster.git?ref=master"
-  namespace            = "eg"
-  stage                = "dev"
-  name                 = "db"
-  engine               = "aurora"
-  engine_mode          = "serverless"
-  cluster_family       = "aurora5.6"
-  cluster_size         = "0"
-  admin_user           = "admin1"
-  admin_password       = "Test123456789"
-  db_name              = "dbname"
-  db_port              = "3306"
-  instance_type        = "db.t2.small"
-  vpc_id               = "vpc-xxxxxxxx"
-  security_groups      = ["sg-xxxxxxxx"]
-  subnets              = ["subnet-xxxxxxxx", "subnet-xxxxxxxx"]
-  zone_id              = "Zxxxxxxxx"
+  source          = "git::https://github.com/cloudposse/terraform-aws-rds-cluster.git?ref=master"
+  namespace       = "eg"
+  stage           = "dev"
+  name            = "db"
+  engine          = "aurora"
+  engine_mode     = "serverless"
+  cluster_family  = "aurora5.6"
+  cluster_size    = "0"
+  admin_user      = "admin1"
+  admin_password  = "Test123456789"
+  db_name         = "dbname"
+  db_port         = "3306"
+  instance_type   = "db.t2.small"
+  vpc_id          = "vpc-xxxxxxxx"
+  security_groups = ["sg-xxxxxxxx"]
+  subnets         = ["subnet-xxxxxxxx", "subnet-xxxxxxxx"]
+  zone_id         = "Zxxxxxxxx"
 
   scaling_configuration = [
     {

--- a/README.md
+++ b/README.md
@@ -134,8 +134,6 @@ module "rds_cluster_aurora_mysql_serverless" {
   security_groups      = ["sg-xxxxxxxx"]
   subnets              = ["subnet-xxxxxxxx", "subnet-xxxxxxxx"]
   zone_id              = "Zxxxxxxxx"
-  enable_http_endpoint = true
-  
 
   scaling_configuration = [
     {

--- a/README.md
+++ b/README.md
@@ -117,23 +117,24 @@ module "rds_cluster_aurora_postgres" {
 
 ```hcl
 module "rds_cluster_aurora_mysql_serverless" {
-  source          = "git::https://github.com/cloudposse/terraform-aws-rds-cluster.git?ref=master"
-  namespace       = "eg"
-  stage           = "dev"
-  name            = "db"
-  engine          = "aurora"
-  engine_mode     = "serverless"
-  cluster_family  = "aurora5.6"
-  cluster_size    = "0"
-  admin_user      = "admin1"
-  admin_password  = "Test123456789"
-  db_name         = "dbname"
-  db_port         = "3306"
-  instance_type   = "db.t2.small"
-  vpc_id          = "vpc-xxxxxxxx"
-  security_groups = ["sg-xxxxxxxx"]
-  subnets         = ["subnet-xxxxxxxx", "subnet-xxxxxxxx"]
-  zone_id         = "Zxxxxxxxx"
+  source               = "git::https://github.com/cloudposse/terraform-aws-rds-cluster.git?ref=master"
+  namespace            = "eg"
+  stage                = "dev"
+  name                 = "db"
+  engine               = "aurora"
+  engine_mode          = "serverless"
+  cluster_family       = "aurora5.6"
+  cluster_size         = "0"
+  admin_user           = "admin1"
+  admin_password       = "Test123456789"
+  db_name              = "dbname"
+  db_port              = "3306"
+  instance_type        = "db.t2.small"
+  vpc_id               = "vpc-xxxxxxxx"
+  security_groups      = ["sg-xxxxxxxx"]
+  subnets              = ["subnet-xxxxxxxx", "subnet-xxxxxxxx"]
+  zone_id              = "Zxxxxxxxx"
+  enable_http_endpoint = true
 
   scaling_configuration = [
     {
@@ -309,6 +310,7 @@ Available targets:
 | db_port | Database port | number | `3306` | no |
 | deletion_protection | If the DB instance should have deletion protection enabled | bool | `false` | no |
 | delimiter | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes` | string | `-` | no |
+| enable_http_endpoint | Enable HTTP endpoint (data API). Only valid when engine_mode is set to serverless | bool | `false` | no |
 | enabled | Set to false to prevent the module from creating any resources | bool | `true` | no |
 | enabled_cloudwatch_logs_exports | List of log types to export to cloudwatch. The following log types are supported: audit, error, general, slowquery | list(string) | `<list>` | no |
 | engine | The name of the database engine to be used for this DB cluster. Valid values: `aurora`, `aurora-mysql`, `aurora-postgresql` | string | `aurora` | no |

--- a/README.md
+++ b/README.md
@@ -117,23 +117,25 @@ module "rds_cluster_aurora_postgres" {
 
 ```hcl
 module "rds_cluster_aurora_mysql_serverless" {
-  source          = "git::https://github.com/cloudposse/terraform-aws-rds-cluster.git?ref=master"
-  namespace       = "eg"
-  stage           = "dev"
-  name            = "db"
-  engine          = "aurora"
-  engine_mode     = "serverless"
-  cluster_family  = "aurora5.6"
-  cluster_size    = "0"
-  admin_user      = "admin1"
-  admin_password  = "Test123456789"
-  db_name         = "dbname"
-  db_port         = "3306"
-  instance_type   = "db.t2.small"
-  vpc_id          = "vpc-xxxxxxxx"
-  security_groups = ["sg-xxxxxxxx"]
-  subnets         = ["subnet-xxxxxxxx", "subnet-xxxxxxxx"]
-  zone_id         = "Zxxxxxxxx"
+  source               = "git::https://github.com/cloudposse/terraform-aws-rds-cluster.git?ref=master"
+  namespace            = "eg"
+  stage                = "dev"
+  name                 = "db"
+  engine               = "aurora"
+  engine_mode          = "serverless"
+  cluster_family       = "aurora5.6"
+  cluster_size         = "0"
+  admin_user           = "admin1"
+  admin_password       = "Test123456789"
+  db_name              = "dbname"
+  db_port              = "3306"
+  instance_type        = "db.t2.small"
+  vpc_id               = "vpc-xxxxxxxx"
+  security_groups      = ["sg-xxxxxxxx"]
+  subnets              = ["subnet-xxxxxxxx", "subnet-xxxxxxxx"]
+  zone_id              = "Zxxxxxxxx"
+  enable_http_endpoint = true
+  
 
   scaling_configuration = [
     {

--- a/README.yaml
+++ b/README.yaml
@@ -89,23 +89,24 @@ usage: |-
 
   ```hcl
   module "rds_cluster_aurora_mysql_serverless" {
-    source          = "git::https://github.com/cloudposse/terraform-aws-rds-cluster.git?ref=master"
-    namespace       = "eg"
-    stage           = "dev"
-    name            = "db"
-    engine          = "aurora"
-    engine_mode     = "serverless"
-    cluster_family  = "aurora5.6"
-    cluster_size    = "0"
-    admin_user      = "admin1"
-    admin_password  = "Test123456789"
-    db_name         = "dbname"
-    db_port         = "3306"
-    instance_type   = "db.t2.small"
-    vpc_id          = "vpc-xxxxxxxx"
-    security_groups = ["sg-xxxxxxxx"]
-    subnets         = ["subnet-xxxxxxxx", "subnet-xxxxxxxx"]
-    zone_id         = "Zxxxxxxxx"
+    source               = "git::https://github.com/cloudposse/terraform-aws-rds-cluster.git?ref=master"
+    namespace            = "eg"
+    stage                = "dev"
+    name                 = "db"
+    engine               = "aurora"
+    engine_mode          = "serverless"
+    cluster_family       = "aurora5.6"
+    cluster_size         = "0"
+    admin_user           = "admin1"
+    admin_password       = "Test123456789"
+    db_name              = "dbname"
+    db_port              = "3306"
+    instance_type        = "db.t2.small"
+    vpc_id               = "vpc-xxxxxxxx"
+    security_groups      = ["sg-xxxxxxxx"]
+    subnets              = ["subnet-xxxxxxxx", "subnet-xxxxxxxx"]
+    zone_id              = "Zxxxxxxxx"
+    enable_http_endpoint = true
 
     scaling_configuration = [
       {

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -26,6 +26,7 @@
 | db_port | Database port | number | `3306` | no |
 | deletion_protection | If the DB instance should have deletion protection enabled | bool | `false` | no |
 | delimiter | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes` | string | `-` | no |
+| enable_http_endpoint | Enable HTTP endpoint (data API). Only valid when engine_mode is set to serverless | bool | `false` | no |
 | enabled | Set to false to prevent the module from creating any resources | bool | `true` | no |
 | enabled_cloudwatch_logs_exports | List of log types to export to cloudwatch. The following log types are supported: audit, error, general, slowquery | list(string) | `<list>` | no |
 | engine | The name of the database engine to be used for this DB cluster. Valid values: `aurora`, `aurora-mysql`, `aurora-postgresql` | string | `aurora` | no |
@@ -51,7 +52,6 @@
 | replication_source_identifier | ARN of a source DB cluster or DB instance if this DB cluster is to be created as a Read Replica | string | `` | no |
 | retention_period | Number of days to retain backups for | number | `5` | no |
 | scaling_configuration | List of nested attributes with scaling properties. Only valid when `engine_mode` is set to `serverless` | object | `<list>` | no |
-| enable_http_endpoint | Enable HTTP endpoint (data API). Only valid when `engine_mode` is set to `serverless` | bool | `false` | no |
 | security_groups | List of security groups to be allowed to connect to the DB instance | list(string) | `<list>` | no |
 | skip_final_snapshot | Determines whether a final DB snapshot is created before the DB cluster is deleted | bool | `true` | no |
 | snapshot_identifier | Specifies whether or not to create this cluster from a snapshot | string | `` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -51,6 +51,7 @@
 | replication_source_identifier | ARN of a source DB cluster or DB instance if this DB cluster is to be created as a Read Replica | string | `` | no |
 | retention_period | Number of days to retain backups for | number | `5` | no |
 | scaling_configuration | List of nested attributes with scaling properties. Only valid when `engine_mode` is set to `serverless` | object | `<list>` | no |
+| enable_http_endpoint | Enable HTTP endpoint (data API).Only valid when `engine_mode` is set to `serverless` | bool | `true` | no |
 | security_groups | List of security groups to be allowed to connect to the DB instance | list(string) | `<list>` | no |
 | skip_final_snapshot | Determines whether a final DB snapshot is created before the DB cluster is deleted | bool | `true` | no |
 | snapshot_identifier | Specifies whether or not to create this cluster from a snapshot | string | `` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -51,7 +51,7 @@
 | replication_source_identifier | ARN of a source DB cluster or DB instance if this DB cluster is to be created as a Read Replica | string | `` | no |
 | retention_period | Number of days to retain backups for | number | `5` | no |
 | scaling_configuration | List of nested attributes with scaling properties. Only valid when `engine_mode` is set to `serverless` | object | `<list>` | no |
-| enable_http_endpoint | Enable HTTP endpoint (data API).Only valid when `engine_mode` is set to `serverless` | bool | `true` | no |
+| enable_http_endpoint | Enable HTTP endpoint (data API). Only valid when `engine_mode` is set to `serverless` | bool | `false` | no |
 | security_groups | List of security groups to be allowed to connect to the DB instance | list(string) | `<list>` | no |
 | skip_final_snapshot | Determines whether a final DB snapshot is created before the DB cluster is deleted | bool | `true` | no |
 | snapshot_identifier | Specifies whether or not to create this cluster from a snapshot | string | `` | no |

--- a/examples/serverless_mysql/main.tf
+++ b/examples/serverless_mysql/main.tf
@@ -14,23 +14,24 @@ provider "aws" {
 }
 
 module "rds_cluster_aurora_mysql_serverless" {
-  source          = "../../"
-  namespace       = "eg"
-  stage           = "dev"
-  name            = "db"
-  engine          = "aurora"
-  engine_mode     = "serverless"
-  cluster_family  = "aurora5.6"
-  cluster_size    = "0"
-  admin_user      = "admin1"
-  admin_password  = "Test123456789"
-  db_name         = "dbname"
-  db_port         = "3306"
-  instance_type   = "db.t2.small"
-  vpc_id          = "vpc-xxxxxxxx"
-  security_groups = ["sg-xxxxxxxx"]
-  subnets         = ["subnet-xxxxxxxx", "subnet-xxxxxxxx"]
-  zone_id         = "Zxxxxxxxx"
+  source               = "../../"
+  namespace            = "eg"
+  stage                = "dev"
+  name                 = "db"
+  engine               = "aurora"
+  engine_mode          = "serverless"
+  cluster_family       = "aurora5.6"
+  cluster_size         = "0"
+  admin_user           = "admin1"
+  admin_password       = "Test123456789"
+  db_name              = "dbname"
+  db_port              = "3306"
+  instance_type        = "db.t2.small"
+  vpc_id               = "vpc-xxxxxxxx"
+  security_groups      = ["sg-xxxxxxxx"]
+  subnets              = ["subnet-xxxxxxxx", "subnet-xxxxxxxx"]
+  zone_id              = "Zxxxxxxxx"
+  enable_http_endpoint = true
 
   scaling_configuration = [
     {

--- a/main.tf
+++ b/main.tf
@@ -68,6 +68,7 @@ resource "aws_rds_cluster" "default" {
   global_cluster_identifier           = var.global_cluster_identifier
   iam_roles                           = var.iam_roles
   backtrack_window                    = var.backtrack_window
+  enable_http_endpoint                = var.engine_mode == "serverless" && var.enable_http_endpoint ? true : false
 
   dynamic "scaling_configuration" {
     for_each = var.scaling_configuration

--- a/variables.tf
+++ b/variables.tf
@@ -374,6 +374,12 @@ variable "backtrack_window" {
   default     = 0
 }
 
+variable "enable_http_endpoint" {
+  type        = bool
+  description = "Enable HTTP endpoint (data API). Only valid when engine_mode is set to serverless"
+  default     = false
+}
+
 variable "vpc_security_group_ids" {
   type        = list(string)
   description = "Additional security group IDs to apply to the cluster, in addition to the provisioned default security group with ingress traffic from existing CIDR blocks and existing security groups"


### PR DESCRIPTION
This PR introduces new option: `enable_http_endpoint` for aurora serverless engine.

As the option in terraform provider is no longer in beta 
 - [reference](https://www.terraform.io/docs/providers/aws/r/rds_cluster.html).

related to: #54 #51