### PR TITLE
use minimum versions for provider pinning

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -170,7 +170,7 @@ locals {
 }
 
 module "dns_master" {
-  source  = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=tags/0.5.0"
+  source  = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=tags/0.6.0"
   enabled = var.enabled && length(var.zone_id) > 0 ? true : false
   name    = local.cluster_dns_name
   zone_id = var.zone_id
@@ -178,7 +178,7 @@ module "dns_master" {
 }
 
 module "dns_replicas" {
-  source  = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=tags/0.5.0"
+  source  = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=tags/0.6.0"
   enabled = var.enabled && length(var.zone_id) > 0 && var.engine_mode != "serverless" ? true : false
   name    = local.reader_dns_name
   zone_id = var.zone_id

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12.0, < 0.14.0"
 
   required_providers {
-    aws  = "~> 2.0"
-    null = "~> 2.0"
+    aws  = ">= 2.0"
+    null = ">= 2.0"
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.0, < 0.14.0"
+  required_version = ">= 0.12.0"
 
   required_providers {
     aws  = ">= 2.0"


### PR DESCRIPTION
## what
set minimum versions for providers without pinning to a specific major version



## why
the current method makes it very difficult to maintain or upgrade consistent provider versions within a project



## references
https://www.terraform.io/docs/configuration/provider-requirements.html#best-practices-for-provider-versions



