### PR TITLE
Fix outputs when `enabled=false`. Change Security Group rules from inline to resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,9 @@ Available targets:
 | master\_username | Username for the master DB user |
 | reader\_endpoint | A read-only endpoint for the Aurora cluster, automatically load-balanced across replicas |
 | replicas\_host | Replicas hostname |
+| security\_group\_arn | Security Group ARN |
+| security\_group\_id | Security Group ID |
+| security\_group\_name | Security Group name |
 
 <!-- markdownlint-restore -->
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -102,5 +102,8 @@
 | master\_username | Username for the master DB user |
 | reader\_endpoint | A read-only endpoint for the Aurora cluster, automatically load-balanced across replicas |
 | replicas\_host | Replicas hostname |
+| security\_group\_arn | Security Group ARN |
+| security\_group\_id | Security Group ID |
+| security\_group\_name | Security Group name |
 
 <!-- markdownlint-restore -->

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -49,13 +49,31 @@ output "cluster_resource_id" {
 }
 
 output "public_subnet_cidrs" {
-  value = module.subnets.public_subnet_cidrs
+  value       = module.subnets.public_subnet_cidrs
+  description = "Public subnet CIDR blocks"
 }
 
 output "private_subnet_cidrs" {
-  value = module.subnets.private_subnet_cidrs
+  value       = module.subnets.private_subnet_cidrs
+  description = "Private subnet CIDR blocks"
 }
 
 output "vpc_cidr" {
-  value = module.vpc.vpc_cidr_block
+  value       = module.vpc.vpc_cidr_block
+  description = "VPC CIDR"
+}
+
+output "security_group_id" {
+  value       = module.rds_cluster.security_group_id
+  description = "Security Group ID"
+}
+
+output "security_group_arn" {
+  value       = module.rds_cluster.security_group_arn
+  description = "Security Group ARN"
+}
+
+output "security_group_name" {
+  value       = module.rds_cluster.security_group_name
+  description = "Security Group name"
 }

--- a/main.tf
+++ b/main.tf
@@ -8,29 +8,40 @@ resource "aws_security_group" "default" {
   name        = module.this.id
   description = "Allow inbound traffic from Security Groups and CIDRs"
   vpc_id      = var.vpc_id
+  tags        = module.this.tags
+}
 
-  ingress {
-    from_port       = var.db_port
-    to_port         = var.db_port
-    protocol        = "tcp"
-    security_groups = var.security_groups
-  }
+resource "aws_security_group_rule" "ingress_security_groups" {
+  count                    = module.this.enabled ? length(var.security_groups) : 0
+  description              = "Allow inbound traffic from existing security groups"
+  type                     = "ingress"
+  from_port                = var.db_port
+  to_port                  = var.db_port
+  protocol                 = "tcp"
+  source_security_group_id = var.security_groups[count.index]
+  security_group_id        = join("", aws_security_group.default.*.id)
+}
 
-  ingress {
-    from_port   = var.db_port
-    to_port     = var.db_port
-    protocol    = "tcp"
-    cidr_blocks = var.allowed_cidr_blocks
-  }
+resource "aws_security_group_rule" "ingress_cidr_blocks" {
+  count             = module.this.enabled && length(var.allowed_cidr_blocks) > 0 ? 1 : 0
+  description       = "Allow inbound traffic from existing CIDR blocks"
+  type              = "ingress"
+  from_port         = var.db_port
+  to_port           = var.db_port
+  protocol          = "tcp"
+  cidr_blocks       = var.allowed_cidr_blocks
+  security_group_id = join("", aws_security_group.default.*.id)
+}
 
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  tags = module.this.tags
+resource "aws_security_group_rule" "egress" {
+  count             = module.this.enabled ? 1 : 0
+  description       = "Allow outbound traffic"
+  type              = "egress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = join("", aws_security_group.default.*.id)
 }
 
 resource "aws_rds_cluster" "primary" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -4,27 +4,27 @@ output "database_name" {
 }
 
 output "master_username" {
-  value       = coalesce(join("", aws_rds_cluster.primary.*.master_username), join("", aws_rds_cluster.secondary.*.master_username))
+  value       = local.is_primary_cluster ? join("", aws_rds_cluster.primary.*.master_username) : join("", aws_rds_cluster.secondary.*.master_username)
   description = "Username for the master DB user"
 }
 
 output "cluster_identifier" {
-  value       = coalesce(join("", aws_rds_cluster.primary.*.cluster_identifier), join("", aws_rds_cluster.secondary.*.cluster_identifier))
+  value       = local.is_primary_cluster ? join("", aws_rds_cluster.primary.*.cluster_identifier) : join("", aws_rds_cluster.secondary.*.cluster_identifier)
   description = "Cluster Identifier"
 }
 
 output "arn" {
-  value       = coalesce(join("", aws_rds_cluster.primary.*.arn), join("", aws_rds_cluster.secondary.*.arn))
+  value       = local.is_primary_cluster ? join("", aws_rds_cluster.primary.*.arn) : join("", aws_rds_cluster.secondary.*.arn)
   description = "Amazon Resource Name (ARN) of the cluster"
 }
 
 output "endpoint" {
-  value       = coalesce(join("", aws_rds_cluster.primary.*.endpoint), join("", aws_rds_cluster.secondary.*.endpoint))
+  value       = local.is_primary_cluster ? join("", aws_rds_cluster.primary.*.endpoint) : join("", aws_rds_cluster.secondary.*.endpoint)
   description = "The DNS address of the RDS instance"
 }
 
 output "reader_endpoint" {
-  value       = coalesce(join("", aws_rds_cluster.primary.*.reader_endpoint), join("", aws_rds_cluster.secondary.*.reader_endpoint))
+  value       = local.is_primary_cluster ? join("", aws_rds_cluster.primary.*.reader_endpoint) : join("", aws_rds_cluster.secondary.*.reader_endpoint)
   description = "A read-only endpoint for the Aurora cluster, automatically load-balanced across replicas"
 }
 
@@ -44,11 +44,26 @@ output "dbi_resource_ids" {
 }
 
 output "cluster_resource_id" {
-  value       = coalesce(join("", aws_rds_cluster.primary.*.cluster_resource_id), join("", aws_rds_cluster.secondary.*.cluster_resource_id))
+  value       = local.is_primary_cluster ? join("", aws_rds_cluster.primary.*.cluster_resource_id) : join("", aws_rds_cluster.secondary.*.cluster_resource_id)
   description = "The region-unique, immutable identifie of the cluster"
 }
 
 output "cluster_security_groups" {
   value       = coalescelist(aws_rds_cluster.primary.*.vpc_security_group_ids, aws_rds_cluster.secondary.*.vpc_security_group_ids, [""])
   description = "Default RDS cluster security groups"
+}
+
+output "security_group_id" {
+  value       = join("", aws_security_group.default.*.id)
+  description = "Security Group ID"
+}
+
+output "security_group_arn" {
+  value       = join("", aws_security_group.default.*.arn)
+  description = "Security Group ARN"
+}
+
+output "security_group_name" {
+  value       = join("", aws_security_group.default.*.name)
+  description = "Security Group name"
 }


### PR DESCRIPTION
## what
* Fix outputs when `enabled=false`
* Change Security Group rules from inline to resources

## why
* Fix outputs when `enabled=false`: `coalesce` will throw error when both parameters are empty
* Change Security Group rules from inline to resources: output the Security Group name, ID and ARN to allow adding other rules to the SG (which is not possible with the inline SG rules, and not possible to mix inline rules with resource-based rules)

## related
* Closes #24 

