### PR TITLE
Add IAM role for enhanced monitoring

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -3,17 +3,17 @@ name: auto-release
 on:
   push:
     branches:
-      - master
+    - master
 
 jobs:
   semver:
     runs-on: ubuntu-latest
     steps:
-      # Drafts your next Release notes as Pull Requests are merged into "master"
-      - uses: release-drafter/release-drafter@v5
-        with:
-          publish: true
-          prerelease: false
-          config-name: auto-release.yml
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    # Drafts your next Release notes as Pull Requests are merged into "master"
+    - uses: release-drafter/release-drafter@v5
+      with:
+        publish: true
+        prerelease: false
+        config-name: auto-release.yml
+      env:
+        GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ Instead pin to the release tag (e.g. `?ref=tags/x.y.z`) of one of our [latest re
 
 
 
+For a complete example, see [examples/complete](examples/complete).
+
+For automated tests of the complete example using [bats](https://github.com/bats-core/bats-core) and [Terratest](https://github.com/gruntwork-io/terratest) (which tests and deploys the example on AWS), see [test](test).
+
 [Basic example](examples/basic)
 
 ```hcl
@@ -77,13 +81,13 @@ module "rds_cluster_aurora_postgres" {
   name            = "postgres"
   engine          = "aurora-postgresql"
   cluster_family  = "aurora-postgresql9.6"
-  cluster_size    = "2"
+  cluster_size    = 2
   namespace       = "eg"
   stage           = "dev"
   admin_user      = "admin1"
   admin_password  = "Test123456789"
   db_name         = "dbname"
-  db_port         = "5432"
+  db_port         = 5432
   instance_type   = "db.r4.large"
   vpc_id          = "vpc-xxxxxxxx"
   security_groups = ["sg-xxxxxxxx"]
@@ -104,11 +108,11 @@ module "rds_cluster_aurora_mysql_serverless" {
   engine               = "aurora"
   engine_mode          = "serverless"
   cluster_family       = "aurora5.6"
-  cluster_size         = "0"
+  cluster_size         = 0
   admin_user           = "admin1"
   admin_password       = "Test123456789"
   db_name              = "dbname"
-  db_port              = "3306"
+  db_port              = 3306
   instance_type        = "db.t2.small"
   vpc_id               = "vpc-xxxxxxxx"
   security_groups      = ["sg-xxxxxxxx"]
@@ -134,7 +138,7 @@ module "rds_cluster_aurora_mysql" {
   source          = "git::https://github.com/cloudposse/terraform-aws-rds-cluster.git?ref=master"
   engine          = "aurora"
   cluster_family  = "aurora-mysql5.7"
-  cluster_size    = "2"
+  cluster_size    = 2
   namespace       = "eg"
   stage           = "dev"
   name            = "db"
@@ -225,14 +229,14 @@ module "rds_cluster_aurora_postgres" {
   source          = "git::https://github.com/cloudposse/terraform-aws-rds-cluster.git?ref=master"
   engine          = "aurora-postgresql"
   cluster_family  = "aurora-postgresql9.6"
-  cluster_size    = "2"
+  cluster_size    = 2
   namespace       = "eg"
   stage           = "dev"
   name            = "db"
   admin_user      = "admin1"
   admin_password  = "Test123456789"
   db_name         = "dbname"
-  db_port         = "5432"
+  db_port         = 5432
   instance_type   = "db.r4.large"
   vpc_id          = "vpc-xxxxxxx"
   security_groups = ["sg-xxxxxxxx"]
@@ -249,6 +253,10 @@ module "rds_cluster_aurora_postgres" {
 
 
 
+
+## Examples
+
+Review the [complete example](examples/complete) to see how to use this module.
 
 
 
@@ -317,6 +325,7 @@ Available targets:
 | engine | The name of the database engine to be used for this DB cluster. Valid values: `aurora`, `aurora-mysql`, `aurora-postgresql` | `string` | `"aurora"` | no |
 | engine\_mode | The database engine mode. Valid values: `parallelquery`, `provisioned`, `serverless` | `string` | `"provisioned"` | no |
 | engine\_version | The version of the database engine to use. See `aws rds describe-db-engine-versions` | `string` | `""` | no |
+| enhanced\_monitoring\_role\_enabled | A boolean flag to enable/disable the creation of the enhanced monitoring IAM role. If set to `false`, the module will not create a new role and will use `rds_monitoring_role_arn` for enhanced monitoring | `bool` | `false` | no |
 | environment | Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
 | global\_cluster\_identifier | ID of the Aurora global cluster | `string` | `""` | no |
 | iam\_database\_authentication\_enabled | Specifies whether or mappings of AWS Identity and Access Management (IAM) accounts to database accounts is enabled | `bool` | `false` | no |
@@ -333,8 +342,8 @@ Available targets:
 | performance\_insights\_enabled | Whether to enable Performance Insights | `bool` | `false` | no |
 | performance\_insights\_kms\_key\_id | The ARN for the KMS key to encrypt Performance Insights data. When specifying `performance_insights_kms_key_id`, `performance_insights_enabled` needs to be set to true | `string` | `""` | no |
 | publicly\_accessible | Set to true if you want your cluster to be publicly accessible (such as via QuickSight) | `bool` | `false` | no |
-| rds\_monitoring\_interval | Interval in seconds that metrics are collected, 0 to disable (values can only be 0, 1, 5, 10, 15, 30, 60) | `number` | `0` | no |
-| rds\_monitoring\_role\_arn | The ARN for the IAM role that can send monitoring metrics to CloudWatch Logs | `string` | `""` | no |
+| rds\_monitoring\_interval | The interval, in seconds, between points when enhanced monitoring metrics are collected for the DB instance. To disable collecting Enhanced Monitoring metrics, specify 0. The default is 0. Valid Values: 0, 1, 5, 10, 15, 30, 60 | `number` | `0` | no |
+| rds\_monitoring\_role\_arn | The ARN for the IAM role that permits RDS to send enhanced monitoring metrics to CloudWatch Logs | `string` | `null` | no |
 | reader\_dns\_name | Name of the reader endpoint CNAME record to create in the parent DNS zone specified by `zone_id`. If left empty, the name will be auto-asigned using the format `replicas.var.name` | `string` | `""` | no |
 | regex\_replace\_chars | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
 | replication\_source\_identifier | ARN of a source DB cluster or DB instance if this DB cluster is to be created as a Read Replica | `string` | `""` | no |

--- a/README.yaml
+++ b/README.yaml
@@ -1,38 +1,50 @@
 name: terraform-aws-rds-cluster
+
 tags:
-- aws
-- terraform
-- terraform-modules
-- databases
-- rds
-- rds-database
-- aurora
-- mysql
-- cluster
+  - aws
+  - terraform
+  - terraform-modules
+  - databases
+  - rds
+  - rds-database
+  - aurora
+  - mysql
+  - cluster
+
 categories:
-- terraform-modules/databases
+  - terraform-modules/databases
+
 license: APACHE2
+
 github_repo: cloudposse/terraform-aws-rds-cluster
+
 badges:
-- name: Latest Release
-  image: https://img.shields.io/github/release/cloudposse/terraform-aws-rds-cluster.svg
-  url: https://github.com/cloudposse/terraform-aws-rds-cluster/releases/latest
-- name: Slack Community
-  image: https://slack.cloudposse.com/badge.svg
-  url: https://slack.cloudposse.com
+  - name: Latest Release
+    image: https://img.shields.io/github/release/cloudposse/terraform-aws-rds-cluster.svg
+    url: https://github.com/cloudposse/terraform-aws-rds-cluster/releases/latest
+  - name: Slack Community
+    image: https://slack.cloudposse.com/badge.svg
+    url: https://slack.cloudposse.com
+
 related:
-- name: terraform-aws-rds
-  description: Terraform module to provision AWS RDS instances
-  url: https://github.com/cloudposse/terraform-aws-rds
-- name: terraform-aws-rds-cloudwatch-sns-alarms
-  description: Terraform module that configures important RDS alerts using CloudWatch
-    and sends them to an SNS topic
-  url: https://github.com/cloudposse/terraform-aws-rds-cloudwatch-sns-alarms
+  - name: terraform-aws-rds
+    description: Terraform module to provision AWS RDS instances
+    url: https://github.com/cloudposse/terraform-aws-rds
+  - name: terraform-aws-rds-cloudwatch-sns-alarms
+    description: Terraform module that configures important RDS alerts using CloudWatch
+      and sends them to an SNS topic
+    url: https://github.com/cloudposse/terraform-aws-rds-cloudwatch-sns-alarms
+
 description: |-
   Terraform module to provision an [`RDS Aurora`](https://aws.amazon.com/rds/aurora) cluster for MySQL or Postgres.
 
   Supports [Amazon Aurora Serverless](https://aws.amazon.com/rds/aurora/serverless/).
+
 usage: |2-
+
+  For a complete example, see [examples/complete](examples/complete).
+
+  For automated tests of the complete example using [bats](https://github.com/bats-core/bats-core) and [Terratest](https://github.com/gruntwork-io/terratest) (which tests and deploys the example on AWS), see [test](test).
 
   [Basic example](examples/basic)
 
@@ -42,13 +54,13 @@ usage: |2-
     name            = "postgres"
     engine          = "aurora-postgresql"
     cluster_family  = "aurora-postgresql9.6"
-    cluster_size    = "2"
+    cluster_size    = 2
     namespace       = "eg"
     stage           = "dev"
     admin_user      = "admin1"
     admin_password  = "Test123456789"
     db_name         = "dbname"
-    db_port         = "5432"
+    db_port         = 5432
     instance_type   = "db.r4.large"
     vpc_id          = "vpc-xxxxxxxx"
     security_groups = ["sg-xxxxxxxx"]
@@ -69,11 +81,11 @@ usage: |2-
     engine               = "aurora"
     engine_mode          = "serverless"
     cluster_family       = "aurora5.6"
-    cluster_size         = "0"
+    cluster_size         = 0
     admin_user           = "admin1"
     admin_password       = "Test123456789"
     db_name              = "dbname"
-    db_port              = "3306"
+    db_port              = 3306
     instance_type        = "db.t2.small"
     vpc_id               = "vpc-xxxxxxxx"
     security_groups      = ["sg-xxxxxxxx"]
@@ -99,7 +111,7 @@ usage: |2-
     source          = "git::https://github.com/cloudposse/terraform-aws-rds-cluster.git?ref=master"
     engine          = "aurora"
     cluster_family  = "aurora-mysql5.7"
-    cluster_size    = "2"
+    cluster_size    = 2
     namespace       = "eg"
     stage           = "dev"
     name            = "db"
@@ -190,14 +202,14 @@ usage: |2-
     source          = "git::https://github.com/cloudposse/terraform-aws-rds-cluster.git?ref=master"
     engine          = "aurora-postgresql"
     cluster_family  = "aurora-postgresql9.6"
-    cluster_size    = "2"
+    cluster_size    = 2
     namespace       = "eg"
     stage           = "dev"
     name            = "db"
     admin_user      = "admin1"
     admin_password  = "Test123456789"
     db_name         = "dbname"
-    db_port         = "5432"
+    db_port         = 5432
     instance_type   = "db.r4.large"
     vpc_id          = "vpc-xxxxxxx"
     security_groups = ["sg-xxxxxxxx"]
@@ -211,23 +223,28 @@ usage: |2-
     rds_monitoring_role_arn = aws_iam_role.enhanced_monitoring.arn
   }
   ```
+
+examples: |-
+  Review the [complete example](examples/complete) to see how to use this module.
+
 include:
-- docs/targets.md
-- docs/terraform.md
+  - docs/targets.md
+  - docs/terraform.md
+
 contributors:
-- name: Erik Osterman
-  github: osterman
-- name: Igor Rodionov
-  github: goruha
-- name: Andriy Knysh
-  github: aknysh
-- name: Sarkis Varozian
-  github: sarkis
-- name: Mike Crowe
-  github: mike-zipit
-- name: Sergey Vasilyev
-  github: s2504s
-- name: Todor Todorov
-  github: tptodorov
-- name: Lee Huffman
-  github: leehuffman
+  - name: Erik Osterman
+    github: osterman
+  - name: Igor Rodionov
+    github: goruha
+  - name: Andriy Knysh
+    github: aknysh
+  - name: Sarkis Varozian
+    github: sarkis
+  - name: Mike Crowe
+    github: mike-zipit
+  - name: Sergey Vasilyev
+    github: s2504s
+  - name: Todor Todorov
+    github: tptodorov
+  - name: Lee Huffman
+    github: leehuffman

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -51,6 +51,7 @@
 | engine | The name of the database engine to be used for this DB cluster. Valid values: `aurora`, `aurora-mysql`, `aurora-postgresql` | `string` | `"aurora"` | no |
 | engine\_mode | The database engine mode. Valid values: `parallelquery`, `provisioned`, `serverless` | `string` | `"provisioned"` | no |
 | engine\_version | The version of the database engine to use. See `aws rds describe-db-engine-versions` | `string` | `""` | no |
+| enhanced\_monitoring\_role\_enabled | A boolean flag to enable/disable the creation of the enhanced monitoring IAM role. If set to `false`, the module will not create a new role and will use `rds_monitoring_role_arn` for enhanced monitoring | `bool` | `false` | no |
 | environment | Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
 | global\_cluster\_identifier | ID of the Aurora global cluster | `string` | `""` | no |
 | iam\_database\_authentication\_enabled | Specifies whether or mappings of AWS Identity and Access Management (IAM) accounts to database accounts is enabled | `bool` | `false` | no |
@@ -67,8 +68,8 @@
 | performance\_insights\_enabled | Whether to enable Performance Insights | `bool` | `false` | no |
 | performance\_insights\_kms\_key\_id | The ARN for the KMS key to encrypt Performance Insights data. When specifying `performance_insights_kms_key_id`, `performance_insights_enabled` needs to be set to true | `string` | `""` | no |
 | publicly\_accessible | Set to true if you want your cluster to be publicly accessible (such as via QuickSight) | `bool` | `false` | no |
-| rds\_monitoring\_interval | Interval in seconds that metrics are collected, 0 to disable (values can only be 0, 1, 5, 10, 15, 30, 60) | `number` | `0` | no |
-| rds\_monitoring\_role\_arn | The ARN for the IAM role that can send monitoring metrics to CloudWatch Logs | `string` | `""` | no |
+| rds\_monitoring\_interval | The interval, in seconds, between points when enhanced monitoring metrics are collected for the DB instance. To disable collecting Enhanced Monitoring metrics, specify 0. The default is 0. Valid Values: 0, 1, 5, 10, 15, 30, 60 | `number` | `0` | no |
+| rds\_monitoring\_role\_arn | The ARN for the IAM role that permits RDS to send enhanced monitoring metrics to CloudWatch Logs | `string` | `null` | no |
 | reader\_dns\_name | Name of the reader endpoint CNAME record to create in the parent DNS zone specified by `zone_id`. If left empty, the name will be auto-asigned using the format `replicas.var.name` | `string` | `""` | no |
 | regex\_replace\_chars | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
 | replication\_source\_identifier | ARN of a source DB cluster or DB instance if this DB cluster is to be created as a Read Replica | `string` | `""` | no |

--- a/enhanced-monitoring.tf
+++ b/enhanced-monitoring.tf
@@ -1,0 +1,43 @@
+# https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Monitoring.OS.html
+# https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster_instance#monitoring_role_arn
+
+module "enhanced_monitoring_label" {
+  source = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.19.2"
+
+  enabled    = module.this.enabled && var.enhanced_monitoring_role_enabled
+  attributes = concat(module.this.attributes, ["enhanced-monitoring"])
+
+  context = module.this.context
+}
+
+# Create IAM role for enhanced monitoring
+resource "aws_iam_role" "enhanced_monitoring" {
+  count              = module.this.enabled && var.enhanced_monitoring_role_enabled ? 1 : 0
+  name               = module.enhanced_monitoring_label.id
+  assume_role_policy = join("", data.aws_iam_policy_document.enhanced_monitoring.*.json)
+}
+
+# Attach Amazon's managed policy for RDS enhanced monitoring
+resource "aws_iam_role_policy_attachment" "enhanced_monitoring" {
+  count      = module.this.enabled && var.enhanced_monitoring_role_enabled ? 1 : 0
+  role       = join("", aws_iam_role.enhanced_monitoring.*.name)
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole"
+}
+
+# Allow RDS monitoring to assume the enhanced monitoring role
+data "aws_iam_policy_document" "enhanced_monitoring" {
+  count = module.this.enabled && var.enhanced_monitoring_role_enabled ? 1 : 0
+
+  statement {
+    actions = [
+      "sts:AssumeRole"
+    ]
+
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["monitoring.rds.amazonaws.com"]
+    }
+  }
+}

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -2,13 +2,6 @@
 
 provider "aws" {
   region = "us-west-1"
-
-  # Make it faster by skipping some checks
-  skip_get_ec2_platforms      = true
-  skip_metadata_api_check     = true
-  skip_region_validation      = true
-  skip_credentials_validation = true
-  skip_requesting_account_id  = true
 }
 
 module "rds_cluster_aurora_postgres" {
@@ -16,13 +9,13 @@ module "rds_cluster_aurora_postgres" {
   name            = "postgres"
   engine          = "aurora-postgresql"
   cluster_family  = "aurora-postgresql9.6"
-  cluster_size    = "2"
+  cluster_size    = 2
   namespace       = "eg"
   stage           = "dev"
   admin_user      = "admin1"
   admin_password  = "Test123456789"
   db_name         = "dbname"
-  db_port         = "5432"
+  db_port         = 5432
   instance_type   = "db.r4.large"
   vpc_id          = "vpc-xxxxxxxx"
   security_groups = ["sg-xxxxxxxx"]

--- a/examples/basic/outputs.tf
+++ b/examples/basic/outputs.tf
@@ -3,13 +3,13 @@ output "name" {
   description = "Database name"
 }
 
-output "user" {
-  value       = module.rds_cluster_aurora_postgres.user
+output "master_username" {
+  value       = module.rds_cluster_aurora_postgres.master_username
   description = "Username for the master DB user"
 }
 
-output "cluster_name" {
-  value       = module.rds_cluster_aurora_postgres.cluster_name
+output "cluster_identifier" {
+  value       = module.rds_cluster_aurora_postgres.cluster_identifier
   description = "Cluster Identifier"
 }
 

--- a/examples/complete/fixtures.us-east-2.tfvars
+++ b/examples/complete/fixtures.us-east-2.tfvars
@@ -29,3 +29,7 @@ db_name = "test_db"
 admin_user = "admin"
 
 admin_password = "admin_password"
+
+enhanced_monitoring_role_enabled = true
+
+rds_monitoring_interval = 30

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -56,3 +56,13 @@ variable "autoscaling_enabled" {
   type        = bool
   description = "Whether to enable cluster autoscaling"
 }
+
+variable "enhanced_monitoring_role_enabled" {
+  type        = bool
+  description = "A boolean flag to enable/disable the creation of the enhanced monitoring IAM role. If set to `false`, the module will not create a new role and will use `rds_monitoring_role_arn` for enhanced monitoring"
+}
+
+variable "rds_monitoring_interval" {
+  type        = number
+  description = "The interval, in seconds, between points when enhanced monitoring metrics are collected for the DB instance. To disable collecting Enhanced Monitoring metrics, specify 0. The default is 0. Valid Values: 0, 1, 5, 10, 15, 30, 60"
+}

--- a/examples/enhanced_monitoring/main.tf
+++ b/examples/enhanced_monitoring/main.tf
@@ -2,13 +2,6 @@
 
 provider "aws" {
   region = "us-west-1"
-
-  # Make it faster by skipping some checks
-  skip_get_ec2_platforms      = true
-  skip_metadata_api_check     = true
-  skip_region_validation      = true
-  skip_credentials_validation = true
-  skip_requesting_account_id  = true
 }
 
 # create IAM role for monitoring
@@ -43,14 +36,14 @@ module "rds_cluster_aurora_postgres" {
   source          = "../../"
   engine          = "aurora-postgresql"
   cluster_family  = "aurora-postgresql9.6"
-  cluster_size    = "2"
+  cluster_size    = 2
   namespace       = "eg"
   stage           = "dev"
   name            = "db"
   admin_user      = "admin1"
   admin_password  = "Test123456789"
   db_name         = "dbname"
-  db_port         = "5432"
+  db_port         = 5432
   instance_type   = "db.r4.large"
   vpc_id          = "vpc-xxxxxxx"
   security_groups = ["sg-xxxxxxxx"]

--- a/examples/enhanced_monitoring/outputs.tf
+++ b/examples/enhanced_monitoring/outputs.tf
@@ -3,13 +3,13 @@ output "name" {
   description = "Database name"
 }
 
-output "user" {
-  value       = module.rds_cluster_aurora_postgres.user
+output "master_username" {
+  value       = module.rds_cluster_aurora_postgres.master_username
   description = "Username for the master DB user"
 }
 
-output "cluster_name" {
-  value       = module.rds_cluster_aurora_postgres.cluster_name
+output "cluster_identifier" {
+  value       = module.rds_cluster_aurora_postgres.cluster_identifier
   description = "Cluster Identifier"
 }
 

--- a/examples/serverless_mysql/main.tf
+++ b/examples/serverless_mysql/main.tf
@@ -4,13 +4,6 @@
 
 provider "aws" {
   region = "us-west-1"
-
-  # Make it faster by skipping some checks
-  skip_get_ec2_platforms      = true
-  skip_metadata_api_check     = true
-  skip_region_validation      = true
-  skip_credentials_validation = true
-  skip_requesting_account_id  = true
 }
 
 module "rds_cluster_aurora_mysql_serverless" {
@@ -21,11 +14,11 @@ module "rds_cluster_aurora_mysql_serverless" {
   engine               = "aurora"
   engine_mode          = "serverless"
   cluster_family       = "aurora5.6"
-  cluster_size         = "0"
+  cluster_size         = 0
   admin_user           = "admin1"
   admin_password       = "Test123456789"
   db_name              = "dbname"
-  db_port              = "3306"
+  db_port              = 3306
   instance_type        = "db.t2.small"
   vpc_id               = "vpc-xxxxxxxx"
   security_groups      = ["sg-xxxxxxxx"]

--- a/examples/serverless_mysql/outputs.tf
+++ b/examples/serverless_mysql/outputs.tf
@@ -3,13 +3,13 @@ output "name" {
   description = "Database name"
 }
 
-output "user" {
-  value       = module.rds_cluster_aurora_mysql_serverless.user
+output "master_username" {
+  value       = module.rds_cluster_aurora_mysql_serverless.master_username
   description = "Username for the master DB user"
 }
 
-output "cluster_name" {
-  value       = module.rds_cluster_aurora_mysql_serverless.cluster_name
+output "cluster_identifier" {
+  value       = module.rds_cluster_aurora_mysql_serverless.cluster_identifier
   description = "Cluster Identifier"
 }
 

--- a/examples/with_cluster_parameters/main.tf
+++ b/examples/with_cluster_parameters/main.tf
@@ -2,20 +2,13 @@
 
 provider "aws" {
   region = "us-west-1"
-
-  # Make it faster by skipping some checks
-  skip_get_ec2_platforms      = true
-  skip_metadata_api_check     = true
-  skip_region_validation      = true
-  skip_credentials_validation = true
-  skip_requesting_account_id  = true
 }
 
 module "rds_cluster_aurora_mysql" {
   source          = "../../"
   engine          = "aurora"
   cluster_family  = "aurora-mysql5.7"
-  cluster_size    = "2"
+  cluster_size    = 2
   namespace       = "eg"
   stage           = "dev"
   name            = "db"

--- a/examples/with_cluster_parameters/outputs.tf
+++ b/examples/with_cluster_parameters/outputs.tf
@@ -3,13 +3,13 @@ output "name" {
   description = "Database name"
 }
 
-output "user" {
-  value       = module.rds_cluster_aurora_mysql.user
+output "master_username" {
+  value       = module.rds_cluster_aurora_mysql.master_username
   description = "Username for the master DB user"
 }
 
-output "cluster_name" {
-  value       = module.rds_cluster_aurora_mysql.cluster_name
+output "cluster_identifier" {
+  value       = module.rds_cluster_aurora_mysql.cluster_identifier
   description = "Cluster Identifier"
 }
 

--- a/main.tf
+++ b/main.tf
@@ -178,7 +178,7 @@ resource "aws_rds_cluster_instance" "default" {
   engine_version                  = var.engine_version
   auto_minor_version_upgrade      = var.auto_minor_version_upgrade
   monitoring_interval             = var.rds_monitoring_interval
-  monitoring_role_arn             = var.rds_monitoring_role_arn
+  monitoring_role_arn             = var.enhanced_monitoring_role_enabled ? join("", aws_iam_role.enhanced_monitoring.*.arn) : var.rds_monitoring_role_arn
   performance_insights_enabled    = var.performance_insights_enabled
   performance_insights_kms_key_id = var.performance_insights_kms_key_id
   availability_zone               = var.instance_availability_zone

--- a/test/src/go.mod
+++ b/test/src/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudposse/terraform-aws-rds-cluster
 
-go 1.13
+go 1.14
 
 require (
 	github.com/aws/aws-sdk-go v1.34.6 // indirect

--- a/variables.tf
+++ b/variables.tf
@@ -214,14 +214,20 @@ variable "iam_database_authentication_enabled" {
 
 variable "rds_monitoring_interval" {
   type        = number
-  description = "Interval in seconds that metrics are collected, 0 to disable (values can only be 0, 1, 5, 10, 15, 30, 60)"
+  description = "The interval, in seconds, between points when enhanced monitoring metrics are collected for the DB instance. To disable collecting Enhanced Monitoring metrics, specify 0. The default is 0. Valid Values: 0, 1, 5, 10, 15, 30, 60"
   default     = 0
 }
 
 variable "rds_monitoring_role_arn" {
   type        = string
-  default     = ""
-  description = "The ARN for the IAM role that can send monitoring metrics to CloudWatch Logs"
+  description = "The ARN for the IAM role that permits RDS to send enhanced monitoring metrics to CloudWatch Logs"
+  default     = null
+}
+
+variable "enhanced_monitoring_role_enabled" {
+  type        = bool
+  description = "A boolean flag to enable/disable the creation of the enhanced monitoring IAM role. If set to `false`, the module will not create a new role and will use `rds_monitoring_role_arn` for enhanced monitoring"
+  default     = false
 }
 
 variable "replication_source_identifier" {


### PR DESCRIPTION
## what
* Add IAM role for enhanced monitoring

## why
* Allow enhanced monitoring for the RDS cluster
* When the IAM role for enhanced monitoring is enabled (variable `enhanced_monitoring_role_enabled` is set to `true`), the module will create an IAM role for enhanced monitoring and assign the managed policy `AmazonRDSEnhancedMonitoringRole` to the role

## references
* https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Monitoring.OS.html
* https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster_instance#monitoring_role_arn

