### PR TITLE
Fixes DNS prepending var.name to local.cluster_dns_name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -247,7 +247,7 @@ locals {
 }
 
 module "dns_master" {
-  source = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=tags/0.6.0"
+  source = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=tags/0.7.0"
 
   enabled  = module.this.enabled && length(var.zone_id) > 0 ? true : false
   dns_name = local.cluster_dns_name
@@ -258,7 +258,7 @@ module "dns_master" {
 }
 
 module "dns_replicas" {
-  source = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=tags/0.6.0"
+  source = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=tags/0.7.0"
 
   enabled  = module.this.enabled && length(var.zone_id) > 0 && var.engine_mode != "serverless" ? true : false
   dns_name = local.reader_dns_name

--- a/main.tf
+++ b/main.tf
@@ -249,10 +249,10 @@ locals {
 module "dns_master" {
   source = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=tags/0.6.0"
 
-  enabled = module.this.enabled && length(var.zone_id) > 0 ? true : false
-  name    = local.cluster_dns_name
-  zone_id = var.zone_id
-  records = coalescelist(aws_rds_cluster.primary.*.endpoint, aws_rds_cluster.secondary.*.endpoint, [""])
+  enabled  = module.this.enabled && length(var.zone_id) > 0 ? true : false
+  dns_name = local.cluster_dns_name
+  zone_id  = var.zone_id
+  records  = coalescelist(aws_rds_cluster.primary.*.endpoint, aws_rds_cluster.secondary.*.endpoint, [""])
 
   context = module.this.context
 }
@@ -260,10 +260,10 @@ module "dns_master" {
 module "dns_replicas" {
   source = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=tags/0.6.0"
 
-  enabled = module.this.enabled && length(var.zone_id) > 0 && var.engine_mode != "serverless" ? true : false
-  name    = local.reader_dns_name
-  zone_id = var.zone_id
-  records = coalescelist(aws_rds_cluster.primary.*.reader_endpoint, aws_rds_cluster.secondary.*.reader_endpoint, [""])
+  enabled  = module.this.enabled && length(var.zone_id) > 0 && var.engine_mode != "serverless" ? true : false
+  dns_name = local.reader_dns_name
+  zone_id  = var.zone_id
+  records  = coalescelist(aws_rds_cluster.primary.*.reader_endpoint, aws_rds_cluster.secondary.*.reader_endpoint, [""])
 
   context = module.this.context
 }


### PR DESCRIPTION
## what
* DNS was changing when it shouldn't have been, it was the value of:

```
${var.name}-${local.cluster_dns_name}
```

I think this may have changed in https://github.com/cloudposse/terraform-aws-route53-cluster-hostname/releases/tag/0.6.0

This changes the parameter to `dns_name` and upgrades the version to get a stable DNS record

## why

* Fix broken DNS