### PR TITLE
Safer security group settings

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -5,10 +5,13 @@ locals {
 
 resource "aws_security_group" "default" {
   count       = module.this.enabled ? 1 : 0
-  name        = module.this.id
+  name_prefix = module.this.id
   description = "Allow inbound traffic from Security Groups and CIDRs"
   vpc_id      = var.vpc_id
   tags        = module.this.tags
+  lifecycle {
+    ignore_changes = [ name, name_prefix ]
+  }
 }
 
 resource "aws_security_group_rule" "ingress_security_groups" {

--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,8 @@ resource "aws_security_group" "default" {
   vpc_id      = var.vpc_id
   tags        = module.this.tags
   lifecycle {
-    ignore_changes = [ name, name_prefix ]
+    create_before_destroy = true
+    ignore_changes        = [name, name_prefix]
   }
 }
 


### PR DESCRIPTION
## what
* Specify a name_prefix, rather than name
* Ignore changes in the security group's name
*  Set the security group as create_before_destroy

## why
* SG name: The default security name is extremely generic and additionally conflicts with itself if the DB is rebuilt
* SG ignore_changes: Security group rebuilds are generally disruptive and should be avoided
* SG create_before_destroy: Minimise disruption when we _do_ have to rebuild

## references
* Fixes #86
