### PR TITLE
Support for cluster cloning requires AWS provider 3.1.15+

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,14 +332,14 @@ Available targets:
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.26 |
-| aws | >= 2.0 |
+| aws | >= 3.1.15 |
 | null | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 2.0 |
+| aws | >= 3.1.15 |
 
 ## Inputs
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -4,14 +4,14 @@
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.26 |
-| aws | >= 2.0 |
+| aws | >= 3.1.15 |
 | null | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 2.0 |
+| aws | >= 3.1.15 |
 
 ## Inputs
 

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.0"
+      version = ">= 3.1.15"
     }
     null = {
       source  = "hashicorp/null"


### PR DESCRIPTION
## what and why

v0.37.0 of this module added support for Aurora cluster cloning and
point-in-time restore [1] which itself was introduced in version
3.1.15 of the AWS provider[2] via the `restore_to_point_in_time`[3]
attribute.

This commits the dependancy on this module to track that requirement
for the newer AWS provider.

## references

[1] https://github.com/cloudposse/terraform-aws-rds-cluster/pull/92
[2] https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md#3150-november-12-2020
[3] https://github.com/hashicorp/terraform-provider-aws/pull/7031

