### PR TITLE
Make security groups only if one is not passed in

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,7 @@ locals {
 }
 
 resource "aws_security_group" "default" {
-  count       = module.this.enabled ? 1 : 0
+  count       = module.this.enabled && length(var.security_groups) == 0 ? 1 : 0
   name        = module.this.id
   description = "Allow inbound traffic from Security Groups and CIDRs"
   vpc_id      = var.vpc_id
@@ -12,7 +12,7 @@ resource "aws_security_group" "default" {
 }
 
 resource "aws_security_group_rule" "ingress_security_groups" {
-  count                    = module.this.enabled ? length(var.security_groups) : 0
+  count                    = module.this.enabled  && length(var.security_groups) == 0 ? 1 : 0
   description              = "Allow inbound traffic from existing security groups"
   type                     = "ingress"
   from_port                = var.db_port
@@ -23,7 +23,7 @@ resource "aws_security_group_rule" "ingress_security_groups" {
 }
 
 resource "aws_security_group_rule" "ingress_cidr_blocks" {
-  count             = module.this.enabled && length(var.allowed_cidr_blocks) > 0 ? 1 : 0
+  count             = module.this.enabled && length(var.allowed_cidr_blocks) > 0 && length(var.security_groups) == 0 ? 1 : 0
   description       = "Allow inbound traffic from existing CIDR blocks"
   type              = "ingress"
   from_port         = var.db_port
@@ -34,7 +34,7 @@ resource "aws_security_group_rule" "ingress_cidr_blocks" {
 }
 
 resource "aws_security_group_rule" "egress" {
-  count             = module.this.enabled ? 1 : 0
+  count             = module.this.enabled && length(var.security_groups) == 0 ? 1 : 0
   description       = "Allow outbound traffic"
   type              = "egress"
   from_port         = 0


### PR DESCRIPTION
## what
* Make security groups only if one is not passed in

## why
* We have an environment that developers cannot create security groups or modify them. In this case they have to pass in security groups that already exist.
