### PR TITLE
create_before_destroy for parameter groups, explicit dependencies

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -75,6 +75,12 @@ resource "aws_rds_cluster" "primary" {
   backtrack_window                    = var.backtrack_window
   enable_http_endpoint                = var.engine_mode == "serverless" && var.enable_http_endpoint ? true : false
 
+  depends_on = [
+    aws_db_subnet_group.default,
+    aws_rds_cluster_parameter_group.default,
+    aws_security_group.default,
+  ]
+
   dynamic "s3_import" {
     for_each = var.s3_import[*]
     content {
@@ -150,6 +156,13 @@ resource "aws_rds_cluster" "secondary" {
   backtrack_window                    = var.backtrack_window
   enable_http_endpoint                = var.engine_mode == "serverless" && var.enable_http_endpoint ? true : false
 
+  depends_on = [
+    aws_db_subnet_group.default,
+    aws_db_parameter_group.default,
+    aws_rds_cluster_parameter_group.default,
+    aws_security_group.default,
+  ]
+
   dynamic "scaling_configuration" {
     for_each = var.scaling_configuration
     content {
@@ -182,7 +195,8 @@ resource "aws_rds_cluster" "secondary" {
 
   lifecycle {
     ignore_changes = [
-      replication_source_identifier
+      replication_source_identifier, # will be set/managed by Global Cluster
+      snapshot_identifier, # if created from a snapshot, will be non-null at creation, but null afterwards
     ]
   }
 }
@@ -204,6 +218,14 @@ resource "aws_rds_cluster_instance" "default" {
   performance_insights_enabled    = var.performance_insights_enabled
   performance_insights_kms_key_id = var.performance_insights_kms_key_id
   availability_zone               = var.instance_availability_zone
+
+  depends_on = [
+    aws_db_subnet_group.default,
+    aws_db_parameter_group.default,
+    aws_iam_role.enhanced_monitoring,
+    aws_rds_cluster.secondary,
+    aws_rds_cluster_parameter_group.default,
+  ]
 }
 
 resource "aws_db_subnet_group" "default" {
@@ -216,7 +238,7 @@ resource "aws_db_subnet_group" "default" {
 
 resource "aws_rds_cluster_parameter_group" "default" {
   count       = module.this.enabled ? 1 : 0
-  name        = module.this.id
+  name_prefix = "${module.this.id}${module.this.delimiter}"
   description = "DB cluster parameter group"
   family      = var.cluster_family
 
@@ -230,11 +252,15 @@ resource "aws_rds_cluster_parameter_group" "default" {
   }
 
   tags = module.this.tags
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_db_parameter_group" "default" {
   count       = module.this.enabled ? 1 : 0
-  name        = module.this.id
+  name_prefix = "${module.this.id}${module.this.delimiter}"
   description = "DB instance parameter group"
   family      = var.cluster_family
 
@@ -248,6 +274,10 @@ resource "aws_db_parameter_group" "default" {
   }
 
   tags = module.this.tags
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 locals {

--- a/main.tf
+++ b/main.tf
@@ -196,7 +196,7 @@ resource "aws_rds_cluster" "secondary" {
   lifecycle {
     ignore_changes = [
       replication_source_identifier, # will be set/managed by Global Cluster
-      snapshot_identifier, # if created from a snapshot, will be non-null at creation, but null afterwards
+      snapshot_identifier,           # if created from a snapshot, will be non-null at creation, but null afterwards
     ]
   }
 }


### PR DESCRIPTION
## what
- Make parameter groups `create_before_destroy`
- Add explicit dependencies

## why
- You cannot delete a parameter group while it is in use, but you can update a database with a new parameter group, so in order to change parameter groups, you need to create a new one, install it, then delete the old one. 
- Some update and destroy operations were failing because resources were being deleted in the wrong order.
