### PR TITLE
Flag `master_username` output as sensitive

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,14 +498,13 @@ Like this project? Please give it a ★ on [our GitHub](https://github.com/cloud
 Are you using this project or any of our other projects? Consider [leaving a testimonial][testimonial]. =)
 
 
+
 ## Related Projects
 
 Check out these related projects.
 
 - [terraform-aws-rds](https://github.com/cloudposse/terraform-aws-rds) - Terraform module to provision AWS RDS instances
 - [terraform-aws-rds-cloudwatch-sns-alarms](https://github.com/cloudposse/terraform-aws-rds-cloudwatch-sns-alarms) - Terraform module that configures important RDS alerts using CloudWatch and sends them to an SNS topic
-
-
 
 ## Help
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -6,6 +6,7 @@ output "database_name" {
 output "master_username" {
   value       = local.is_regional_cluster ? join("", aws_rds_cluster.primary.*.master_username) : join("", aws_rds_cluster.secondary.*.master_username)
   description = "Username for the master DB user"
+  sensitive   = true
 }
 
 output "cluster_identifier" {


### PR DESCRIPTION
## what
* Flag `master_username` output as sensitive

## why

Running on Terraform Cloud

```
Terraform v0.14.5
Configuring remote state backend...
Initializing Terraform configuration...

Error: Output refers to sensitive values

  on .terraform/modules/db/outputs.tf line 6:
   6: output "master_username" {

Expressions used in outputs can only refer to sensitive values if the
sensitive attribute is true.
```

## references
* https://www.terraform.io/upgrade-guides/0-14.html#sensitive-values-in-plan-output

