### PR TITLE
Ignore `engine_version` for rds instance in order to upgrade without recreating db instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,14 +498,13 @@ Like this project? Please give it a ★ on [our GitHub](https://github.com/cloud
 Are you using this project or any of our other projects? Consider [leaving a testimonial][testimonial]. =)
 
 
+
 ## Related Projects
 
 Check out these related projects.
 
 - [terraform-aws-rds](https://github.com/cloudposse/terraform-aws-rds) - Terraform module to provision AWS RDS instances
 - [terraform-aws-rds-cloudwatch-sns-alarms](https://github.com/cloudposse/terraform-aws-rds-cloudwatch-sns-alarms) - Terraform module that configures important RDS alerts using CloudWatch and sends them to an SNS topic
-
-
 
 ## Help
 

--- a/main.tf
+++ b/main.tf
@@ -228,6 +228,10 @@ resource "aws_rds_cluster_instance" "default" {
     aws_rds_cluster.secondary,
     aws_rds_cluster_parameter_group.default,
   ]
+
+  lifecycle {
+    ignore_changes = [engine_version]
+  }
 }
 
 resource "aws_db_subnet_group" "default" {


### PR DESCRIPTION
## what
* Ignore `engine_version` for rds instance in order to upgrade

## why
* When the `engine_version` for the `aws_rds_cluster` is changed and applied, the db instances will be upgraded.
* There is a note on the [rds_cluster_instance#engine_version](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster_instance#engine_version) which states
    > (Optional, Forces new resource) The database engine version. When managing the engine version in the cluster, it is recommended to add the [lifecycle `ignore_changes` configuration](https://www.terraform.io/docs/configuration/meta-arguments/lifecycle.html#ignore_changes) for this argument to prevent Terraform from proposing changes to the instance engine version directly.

<details><summary>terraform plan</summary>

```diff
  # module.primary_aurora_postgres_cluster.aws_rds_cluster_instance.default[0] must be replaced
+/- resource "aws_rds_cluster_instance" "default" {
      + apply_immediately               = (known after apply)
      ~ arn                             = "arn:aws:rds:us-east-2:snip:db:snip-1" -> (known after apply)
      ~ availability_zone               = "us-east-2c" -> (known after apply)
      ~ ca_cert_identifier              = "rds-ca-2019" -> (known after apply)
      ~ dbi_resource_id                 = "db-snip" -> (known after apply)
      ~ endpoint                        = "snip-1.snip.us-east-2.rds.amazonaws.com" -> (known after apply)
      ~ engine_version                  = "12.4" -> "12.6" # forces replacement
      ~ id                              = "snip-1" -> (known after apply)
      + identifier_prefix               = (known after apply)
      ~ kms_key_id                      = "arn:aws:kms:us-east-2:snip:key/snip" -> (known after apply)
      + monitoring_role_arn             = (known after apply)
      + performance_insights_kms_key_id = (known after apply)
      ~ port                            = 5432 -> (known after apply)
      ~ preferred_backup_window         = "07:00-09:00" -> (known after apply)
      ~ preferred_maintenance_window    = "sun:07:32-sun:08:02" -> (known after apply)
      ~ storage_encrypted               = true -> (known after apply)
      ~ writer                          = true -> (known after apply)
        # (13 unchanged attributes hidden)
    }
```
</details>

<details><summary>terraform apply (error)</summary>

```shell
module.primary_aurora_postgres_cluster.aws_rds_cluster_instance.default[0]: Creating...
╷
│ Error: error creating RDS Cluster (snip) Instance: DBInstanceAlreadyExists: DB Instance already exists
│ 	status code: 400, request id: snip
│ 
│   with module.primary_aurora_postgres_cluster.aws_rds_cluster_instance.default[0],
│   on main.tf line 206, in resource "aws_rds_cluster_instance" "default":
│  206: resource "aws_rds_cluster_instance" "default" {
│ 
╵
```
</details>

<details><summary>terraform plan (no changes)</summary>

```shell
Note: Objects have changed outside of Terraform

Terraform detected the following changes made outside of Terraform since the last "terraform
apply":

  # module.primary_aurora_postgres_cluster.aws_rds_cluster_instance.default[0] has been changed
  ~ resource "aws_rds_cluster_instance" "default" {
      ~ engine_version               = "12.4" -> "12.6"
        id                           = "snip-1"
        # (24 unchanged attributes hidden)
    }

Unless you have made equivalent changes to your configuration, or ignored the relevant
attributes using ignore_changes, the following plan may include actions to undo or respond to
these changes.

No changes. Your infrastructure matches the configuration.
```
</details>

Confirmed in the AWS console that the postgres aurora rds instance and cluster are `12.6`.

## references
N/A