### PR TITLE
Update AWS provider minimum version

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,14 +356,14 @@ Available targets:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.1.15 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.63.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.1.15 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.63.0 |
 
 ## Modules
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -4,14 +4,14 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.1.15 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.63.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.1.15 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.63.0 |
 
 ## Modules
 

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.1.15"
+      version = ">= 3.63.0"
     }
     null = {
       source  = "hashicorp/null"


### PR DESCRIPTION
## what
* c96d859 added performance_insights_retention_period, which is supported in AWS provider v3.63.0 onwards.

## why
* Prevent issues with older cached aws providers

## references
N/A