### PR TITLE
Create dns record if not serverless

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -328,7 +328,7 @@ module "dns_replicas" {
   source  = "cloudposse/route53-cluster-hostname/aws"
   version = "0.12.2"
 
-  enabled  = local.enabled && length(var.zone_id) > 0 && local.is_serverless && local.cluster_instance_count > 0
+  enabled  = local.enabled && length(var.zone_id) > 0 && ! local.is_serverless && local.cluster_instance_count > 0
   dns_name = local.reader_dns_name
   zone_id  = var.zone_id
   records  = coalescelist(aws_rds_cluster.primary.*.reader_endpoint, aws_rds_cluster.secondary.*.reader_endpoint, [""])


### PR DESCRIPTION
## what
* Restore original logic

## why
* Previous logic was to create the record when module was not serverless

## references
* Previous PR https://github.com/cloudposse/terraform-aws-rds-cluster/pull/124

