### PR TITLE
Add subnet_group_name parameter to allow overriding the default label…

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,6 +475,7 @@ Available targets:
 | <a name="input_source_region"></a> [source\_region](#input\_source\_region) | Source Region of primary cluster, needed when using encrypted storage and region replicas | `string` | `""` | no |
 | <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | <a name="input_storage_encrypted"></a> [storage\_encrypted](#input\_storage\_encrypted) | Specifies whether the DB cluster is encrypted. The default is `false` for `provisioned` `engine_mode` and `true` for `serverless` `engine_mode` | `bool` | `false` | no |
+| <a name="input_subnet_group_name"></a> [subnet\_group\_name](#input\_subnet\_group\_name) | Database subnet group name. Will use generated label ID if not supplied. | `string` | `""` | no |
 | <a name="input_subnets"></a> [subnets](#input\_subnets) | List of VPC subnet IDs | `list(string)` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).<br>Neither the tag keys nor the tag values will be modified by this module. | `map(string)` | `{}` | no |
 | <a name="input_tenant"></a> [tenant](#input\_tenant) | ID element \_(Rarely used, not included by default)\_. A customer identifier, indicating who this instance of a resource is for | `string` | `null` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -123,6 +123,7 @@
 | <a name="input_source_region"></a> [source\_region](#input\_source\_region) | Source Region of primary cluster, needed when using encrypted storage and region replicas | `string` | `""` | no |
 | <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | <a name="input_storage_encrypted"></a> [storage\_encrypted](#input\_storage\_encrypted) | Specifies whether the DB cluster is encrypted. The default is `false` for `provisioned` `engine_mode` and `true` for `serverless` `engine_mode` | `bool` | `false` | no |
+| <a name="input_subnet_group_name"></a> [subnet\_group\_name](#input\_subnet\_group\_name) | Database subnet group name. Will use generated label ID if not supplied. | `string` | `""` | no |
 | <a name="input_subnets"></a> [subnets](#input\_subnets) | List of VPC subnet IDs | `list(string)` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).<br>Neither the tag keys nor the tag values will be modified by this module. | `map(string)` | `{}` | no |
 | <a name="input_tenant"></a> [tenant](#input\_tenant) | ID element \_(Rarely used, not included by default)\_. A customer identifier, indicating who this instance of a resource is for | `string` | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -261,7 +261,7 @@ resource "aws_rds_cluster_instance" "default" {
 
 resource "aws_db_subnet_group" "default" {
   count       = local.enabled ? 1 : 0
-  name        = module.this.id
+  name        = var.subnet_group_name == "" ? module.this.id : var.subnet_group_name
   description = "Allowed subnets for DB cluster instances"
   subnet_ids  = var.subnets
   tags        = module.this.tags

--- a/variables.tf
+++ b/variables.tf
@@ -423,3 +423,9 @@ variable "enhanced_monitoring_attributes" {
   type        = list(string)
   default     = ["enhanced-monitoring"]
 }
+
+variable "subnet_group_name" {
+  description = "Database subnet group name. Will use generated label ID if not supplied."
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
## what
* Allow the user to specify the db_subnet_group name, rather than using the default label ID

## why
* If importing an existing database cluster and subnet group, we need to be able to set the subnet group name to what it already has, otherwise the subnet group will be recreated. This in turn will cause the database cluster to be recreated, which we don't want.

## references
* https://sweetops.slack.com/archives/CB6GHNLG0/p1646336110444589
