### PR TITLE
Bump aws to v4.6.0

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.63.0"
+      version = ">= 4.6.0"
     }
     null = {
       source  = "hashicorp/null"


### PR DESCRIPTION
## what
* Bump aws to v4.6.0

## why
* Allow minor upgrades to work

## references
* See this fix in v4.6.0 https://github.com/hashicorp/terraform-provider-aws/issues/21879

