### PR TITLE
Fix: Upgrading DB version fails with InvalidParameterCombination for instance parameter group

### DIFF
--- a/.github/auto-release.yml
+++ b/.github/auto-release.yml
@@ -17,7 +17,6 @@ version-resolver:
     - 'bugfix'
     - 'bug'
     - 'hotfix'
-    - 'no-release'
   default: 'minor'
 
 categories:

--- a/main.tf
+++ b/main.tf
@@ -97,6 +97,7 @@ resource "aws_rds_cluster" "primary" {
   engine                              = var.engine
   engine_version                      = var.engine_version
   allow_major_version_upgrade         = var.allow_major_version_upgrade
+  db_instance_parameter_group_name    = var.allow_major_version_upgrade ? join("", aws_db_parameter_group.default.*.name) : null
   engine_mode                         = var.engine_mode
   iam_roles                           = var.iam_roles
   backtrack_window                    = var.backtrack_window


### PR DESCRIPTION
## what
* Pass a value to db_instance_parameter_group_name argument when allow_major_version_upgrade is true.

## why
* When absent, the upgrade process would fail with _InvalidParameterCombination_ exception thrown from AWS provider.

## references
* closes #134 
* [Terraform aws_rds_cluster resource documentation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster#db_instance_parameter_group_name)

