### PR TITLE
Add to output identifiers for DB instances in the cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -500,6 +500,7 @@ Available targets:
 | <a name="output_cluster_resource_id"></a> [cluster\_resource\_id](#output\_cluster\_resource\_id) | The region-unique, immutable identifie of the cluster |
 | <a name="output_cluster_security_groups"></a> [cluster\_security\_groups](#output\_cluster\_security\_groups) | Default RDS cluster security groups |
 | <a name="output_database_name"></a> [database\_name](#output\_database\_name) | Database name |
+| <a name="output_dbi_ids"></a> [dbi\_ids](#output\_dbi\_ids) | List of the identifiers for the DB instances in the cluster |
 | <a name="output_dbi_resource_ids"></a> [dbi\_resource\_ids](#output\_dbi\_resource\_ids) | List of the region-unique, immutable identifiers for the DB instances in the cluster |
 | <a name="output_endpoint"></a> [endpoint](#output\_endpoint) | The DNS address of the RDS instance |
 | <a name="output_master_host"></a> [master\_host](#output\_master\_host) | DB Master hostname |

--- a/README.md
+++ b/README.md
@@ -683,7 +683,7 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
 
 [![README Footer][readme_footer_img]][readme_footer_link]
 [![Beacon][beacon]][website]
-
+<!-- markdownlint-disable -->
   [logo]: https://cloudposse.com/logo-300x69.svg
   [docs]: https://cpco.io/docs?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-rds-cluster&utm_content=docs
   [website]: https://cpco.io/homepage?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-rds-cluster&utm_content=website
@@ -714,3 +714,4 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
   [share_googleplus]: https://plus.google.com/share?url=https://github.com/cloudposse/terraform-aws-rds-cluster
   [share_email]: mailto:?subject=terraform-aws-rds-cluster&body=https://github.com/cloudposse/terraform-aws-rds-cluster
   [beacon]: https://ga-beacon.cloudposse.com/UA-76589703-4/cloudposse/terraform-aws-rds-cluster?pixel&cs=github&cm=readme&an=terraform-aws-rds-cluster
+<!-- markdownlint-restore -->

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -148,6 +148,7 @@
 | <a name="output_cluster_resource_id"></a> [cluster\_resource\_id](#output\_cluster\_resource\_id) | The region-unique, immutable identifie of the cluster |
 | <a name="output_cluster_security_groups"></a> [cluster\_security\_groups](#output\_cluster\_security\_groups) | Default RDS cluster security groups |
 | <a name="output_database_name"></a> [database\_name](#output\_database\_name) | Database name |
+| <a name="output_dbi_ids"></a> [dbi\_ids](#output\_dbi\_ids) | List of the identifiers for the DB instances in the cluster |
 | <a name="output_dbi_resource_ids"></a> [dbi\_resource\_ids](#output\_dbi\_resource\_ids) | List of the region-unique, immutable identifiers for the DB instances in the cluster |
 | <a name="output_endpoint"></a> [endpoint](#output\_endpoint) | The DNS address of the RDS instance |
 | <a name="output_master_host"></a> [master\_host](#output\_master\_host) | DB Master hostname |

--- a/outputs.tf
+++ b/outputs.tf
@@ -39,6 +39,11 @@ output "replicas_host" {
   description = "Replicas hostname"
 }
 
+output "dbi_ids" {
+  value       = aws_rds_cluster_instance.default.*.id
+  description = "List of the identifiers for the DB instances in the cluster"
+}
+
 output "dbi_resource_ids" {
   value       = aws_rds_cluster_instance.default.*.dbi_resource_id
   description = "List of the region-unique, immutable identifiers for the DB instances in the cluster"


### PR DESCRIPTION
## what
Adding to output identifiers of DB instances

## why
We are trying to setup https://github.com/cloudposse/terraform-aws-rds-cloudwatch-sns-alarms module for our rds cluster that is created through this one module. terraform-aws-rds-cloudwatch-sns-alarms requires to pass **db_instance_id** but we have a lack of dbi_ids as an output.

