### PR TITLE
Itterate over cidrs in allowed_cidr_blocks

### DIFF
--- a/.github/workflows/validate-codeowners.yml
+++ b/.github/workflows/validate-codeowners.yml
@@ -10,6 +10,7 @@ jobs:
     steps:
     - name: "Checkout source code at current commit"
       uses: actions/checkout@v2
+      # Leave pinned at 0.7.1 until https://github.com/mszostok/codeowners-validator/issues/173 is resolved
     - uses: mszostok/codeowners-validator@v0.7.1
       if: github.event.pull_request.head.repo.full_name == github.repository
       name: "Full check of CODEOWNERS"

--- a/README.md
+++ b/README.md
@@ -682,7 +682,7 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
 
 [![README Footer][readme_footer_img]][readme_footer_link]
 [![Beacon][beacon]][website]
-
+<!-- markdownlint-disable -->
   [logo]: https://cloudposse.com/logo-300x69.svg
   [docs]: https://cpco.io/docs?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-rds-cluster&utm_content=docs
   [website]: https://cpco.io/homepage?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-rds-cluster&utm_content=website
@@ -713,3 +713,4 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
   [share_googleplus]: https://plus.google.com/share?url=https://github.com/cloudposse/terraform-aws-rds-cluster
   [share_email]: mailto:?subject=terraform-aws-rds-cluster&body=https://github.com/cloudposse/terraform-aws-rds-cluster
   [beacon]: https://ga-beacon.cloudposse.com/UA-76589703-4/cloudposse/terraform-aws-rds-cluster?pixel&cs=github&cm=readme&an=terraform-aws-rds-cluster
+<!-- markdownlint-restore -->

--- a/main.tf
+++ b/main.tf
@@ -52,7 +52,7 @@ resource "aws_security_group_rule" "ingress_cidr_blocks" {
   from_port         = var.db_port
   to_port           = var.db_port
   protocol          = "tcp"
-  cidr_blocks       = [ each.key ]
+  cidr_blocks       = [each.key]
   security_group_id = join("", aws_security_group.default.*.id)
 }
 

--- a/main.tf
+++ b/main.tf
@@ -46,13 +46,13 @@ resource "aws_security_group_rule" "traffic_inside_security_group" {
 }
 
 resource "aws_security_group_rule" "ingress_cidr_blocks" {
-  for_each          = local.allowed_cidr_blocks
+  for_each          = toset(local.allowed_cidr_blocks)
   description       = "Allow inbound traffic from existing CIDR blocks"
   type              = "ingress"
   from_port         = var.db_port
   to_port           = var.db_port
   protocol          = "tcp"
-  cidr_blocks       = [each.key]
+  cidr_blocks       = [ each.key ]
   security_group_id = join("", aws_security_group.default.*.id)
 }
 


### PR DESCRIPTION


## what
This should create individual sg rules from each cidr in the list of cidrs passed in and none if not enabled.

## why
It seems that terraform wants to add only one cidr block to each security group rule. 
This should fix that. 

