### PR TITLE
fix: apply db_port to actual instance

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -45,6 +45,7 @@ module "rds_cluster" {
   iops                                 = var.iops
   allocated_storage                    = var.allocated_storage
   intra_security_group_traffic_enabled = var.intra_security_group_traffic_enabled
+  storage_encrypted                    = true
 
   cluster_parameters = [
     {

--- a/main.tf
+++ b/main.tf
@@ -102,6 +102,7 @@ resource "aws_rds_cluster" "primary" {
   iam_roles                           = var.iam_roles
   backtrack_window                    = var.backtrack_window
   enable_http_endpoint                = local.is_serverless && var.enable_http_endpoint
+  port                                = var.db_port
 
   depends_on = [
     aws_db_subnet_group.default,
@@ -192,6 +193,7 @@ resource "aws_rds_cluster" "secondary" {
   iam_roles                           = var.iam_roles
   backtrack_window                    = var.backtrack_window
   enable_http_endpoint                = local.is_serverless && var.enable_http_endpoint
+  port                                = var.db_port
 
   depends_on = [
     aws_db_subnet_group.default,


### PR DESCRIPTION
## what

Makes the db_port effective. Currently it only modifies the security group, not the actual RDS port.

## why

The current variable is broken, it modifies the security group but not the underlying cluster, therefore it's actually renders the variable ineffective as is. In fact if you do not set it do the default for the database type, the use of the module will not work.

## references

- Resolves #120
