### PR TITLE
Add serverlessv2_scaling_configuration to secondary cluster

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -250,10 +250,10 @@ resource "aws_rds_cluster" "secondary" {
 resource "aws_rds_cluster_instance" "default" {
   count                                 = local.cluster_instance_count
   identifier                            = var.cluster_identifier == "" ? "${module.this.id}-${count.index + 1}" : "${var.cluster_identifier}-${count.index + 1}"
-  cluster_identifier                    = coalesce(join("", aws_rds_cluster.primary.*.id), join("", aws_rds_cluster.secondary.*.id))
+  cluster_identifier                    = coalesce(join("", aws_rds_cluster.primary[*].id), join("", aws_rds_cluster.secondary[*].id))
   instance_class                        = var.instance_type
-  db_subnet_group_name                  = join("", aws_db_subnet_group.default.*.name)
-  db_parameter_group_name               = join("", aws_db_parameter_group.default.*.name)
+  db_subnet_group_name                  = join("", aws_db_subnet_group.default[*].name)
+  db_parameter_group_name               = join("", aws_db_parameter_group.default[*].name)
   publicly_accessible                   = var.publicly_accessible
   tags                                  = module.this.tags
   engine                                = var.engine

--- a/main.tf
+++ b/main.tf
@@ -211,6 +211,14 @@ resource "aws_rds_cluster" "secondary" {
     }
   }
 
+  dynamic "serverlessv2_scaling_configuration" {
+    for_each = var.serverlessv2_scaling_configuration[*]
+    content {
+      max_capacity = serverlessv2_scaling_configuration.value.max_capacity
+      min_capacity = serverlessv2_scaling_configuration.value.min_capacity
+    }
+  }
+
   dynamic "timeouts" {
     for_each = var.timeouts_configuration
     content {

--- a/main.tf
+++ b/main.tf
@@ -250,7 +250,7 @@ resource "aws_rds_cluster_instance" "default" {
   count                                 = local.cluster_instance_count
   identifier                            = var.cluster_identifier == "" ? "${module.this.id}-${count.index + 1}" : "${var.cluster_identifier}-${count.index + 1}"
   cluster_identifier                    = coalesce(join("", aws_rds_cluster.primary.*.id), join("", aws_rds_cluster.secondary.*.id))
-  instance_class                        = var.instance_type
+  instance_class                        = var.serverlessv2_scaling_configuration != null ? "db.serverless" : var.instance_type
   db_subnet_group_name                  = join("", aws_db_subnet_group.default.*.name)
   db_parameter_group_name               = join("", aws_db_parameter_group.default.*.name)
   publicly_accessible                   = var.publicly_accessible

--- a/main.tf
+++ b/main.tf
@@ -250,7 +250,7 @@ resource "aws_rds_cluster_instance" "default" {
   count                                 = local.cluster_instance_count
   identifier                            = var.cluster_identifier == "" ? "${module.this.id}-${count.index + 1}" : "${var.cluster_identifier}-${count.index + 1}"
   cluster_identifier                    = coalesce(join("", aws_rds_cluster.primary.*.id), join("", aws_rds_cluster.secondary.*.id))
-  instance_class                        = var.serverlessv2_scaling_configuration != null ? "db.serverless" : var.instance_type
+  instance_class                        = var.instance_type
   db_subnet_group_name                  = join("", aws_db_subnet_group.default.*.name)
   db_parameter_group_name               = join("", aws_db_parameter_group.default.*.name)
   publicly_accessible                   = var.publicly_accessible

--- a/main.tf
+++ b/main.tf
@@ -175,6 +175,7 @@ resource "aws_rds_cluster" "secondary" {
   final_snapshot_identifier           = var.cluster_identifier == "" ? lower(module.this.id) : lower(var.cluster_identifier)
   skip_final_snapshot                 = var.skip_final_snapshot
   apply_immediately                   = var.apply_immediately
+  db_cluster_instance_class           = local.is_serverless ? null : var.db_cluster_instance_class
   storage_encrypted                   = var.storage_encrypted
   kms_key_id                          = var.kms_key_arn
   source_region                       = var.source_region
@@ -250,7 +251,7 @@ resource "aws_rds_cluster_instance" "default" {
   count                                 = local.cluster_instance_count
   identifier                            = var.cluster_identifier == "" ? "${module.this.id}-${count.index + 1}" : "${var.cluster_identifier}-${count.index + 1}"
   cluster_identifier                    = coalesce(join("", aws_rds_cluster.primary.*.id), join("", aws_rds_cluster.secondary.*.id))
-  instance_class                        = var.serverlessv2_scaling_configuration != null ? "db.serverless" : var.instance_type
+  instance_class                        = var.instance_type
   db_subnet_group_name                  = join("", aws_db_subnet_group.default.*.name)
   db_parameter_group_name               = join("", aws_db_parameter_group.default.*.name)
   publicly_accessible                   = var.publicly_accessible


### PR DESCRIPTION
## what

Add aurora serverlessv2 support for configuration of `cluster_type="global"`.

## why

In the PR #138 , the `serverlessv2_scaling_configuration` argument was only added to the resource `aws_rds_cluster.primary`, which is in effect when clsuter_type is `regional`. It should also be added to the resource `aws_rds_cluster.secondary` to cover the case when cluster_type is `global`.

## references

https://github.com/cloudposse/terraform-aws-rds-cluster/pull/138