### PR TITLE
support network_type parameter

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -211,6 +211,13 @@ variable "allowed_cidr_blocks" {
   description = "List of CIDR blocks allowed to access the cluster"
 }
 
+variable "allowed_ipv6_cidr_blocks" {
+  type        = list(string)
+  default     = []
+  description = "List of IPv6 CIDR blocks allowed to access the cluster"
+}
+
+
 variable "publicly_accessible" {
   type        = bool
   description = "Set to true if you want your cluster to be publicly accessible (such as via QuickSight)"
@@ -489,4 +496,10 @@ variable "activity_stream_kms_key_id" {
   type        = string
   default     = ""
   description = "The ARN for the KMS key to encrypt Activity Stream Data data. When specifying `activity_stream_kms_key_id`, `activity_stream_enabled` needs to be set to true"
+}
+
+variable "network_type" {
+  type        = string
+  default     = "IPV4"
+  description = "The network type of the cluster. Valid values: IPV4, DUAL."
 }


### PR DESCRIPTION
## what
RDS cluster can be run in two network modes - IPV4 or DUAL.
Underlying module already supports this parameter
<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

## why

It can be mandatory to enable it to be able to connect from ipv6 only runtimes
<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

## references

Closes https://github.com/cloudposse/terraform-aws-rds-cluster/issues/175
<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
