### PR TITLE
feat!: allow null values for backup_window and retention_period

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -74,13 +74,13 @@ variable "admin_password" {
 
 variable "retention_period" {
   type        = number
-  default     = 5
+  default     = null
   description = "Number of days to retain backups for"
 }
 
 variable "backup_window" {
   type        = string
-  default     = "07:00-09:00"
+  default     = null
   description = "Daily time range during which the backups happen"
 }
 


### PR DESCRIPTION
## what

Sets the default for backup_window and retention_period to `null`.

BREAKING CHANGE: backup_window and retention_period are now `null` by default. If you want to keep the old
default configuration, set `backup_window = "07:00-09:00"` and `retention_period = 5`.

## why

When AWS backup is used, the settings either have to match the AWS backup settings exactly or they
have to be unset.

Trying to apply any diverging settings will result in an error:

```
InvalidParameterValue: RDS cluster $name is associated with the following AwsBackupRecoveryPointArn: arn:aws:backup:$region:$account:recovery-point:$mode:cluster-$id. The BackupRetentionPeriod can be blank, or you can use the current value, $current_value. For more details, see the AWS Backup documentation
```

Since matching these settings manually defeats the purpose of having a single source of truth,
this change updates the default values to be `null`.

I would prefer to make this a non-breaking change, but without adding another variable, this seems to not be possible
since a default can't be overridden with `null`.

## references

This is possible since https://github.com/hashicorp/terraform-provider-aws/issues/33465 was merged for `aws_rds_cluster` resources.
