### PR TITLE
feat: manage master credentials in secrets manager 

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -72,8 +72,10 @@ resource "aws_rds_cluster" "primary" {
   count                               = local.enabled && local.is_regional_cluster ? 1 : 0
   cluster_identifier                  = var.cluster_identifier == "" ? module.this.id : var.cluster_identifier
   database_name                       = var.db_name
+  manage_master_user_password         = var.manage_admin_user_password
+  master_user_secret_kms_key_id       = var.admin_user_secret_kms_key_id
   master_username                     = local.ignore_admin_credentials ? null : var.admin_user
-  master_password                     = local.ignore_admin_credentials ? null : var.admin_password
+  master_password                     = local.ignore_admin_credentials || var.manage_admin_user_password ? null : var.admin_password
   backup_retention_period             = var.retention_period
   preferred_backup_window             = var.backup_window
   copy_tags_to_snapshot               = var.copy_tags_to_snapshot
@@ -171,6 +173,8 @@ resource "aws_rds_cluster" "secondary" {
   count                               = local.enabled && !local.is_regional_cluster ? 1 : 0
   cluster_identifier                  = var.cluster_identifier == "" ? module.this.id : var.cluster_identifier
   database_name                       = var.db_name
+  manage_master_user_password         = var.manage_admin_user_password
+  master_user_secret_kms_key_id       = var.admin_user_secret_kms_key_id
   master_username                     = local.ignore_admin_credentials ? null : var.admin_user
   master_password                     = local.ignore_admin_credentials ? null : var.admin_password
   backup_retention_period             = var.retention_period

--- a/variables.tf
+++ b/variables.tf
@@ -60,6 +60,18 @@ variable "db_port" {
   description = "Database port"
 }
 
+variable "manage_admin_user_password" {
+  type = string
+  default = false
+  description = "Set to true to allow RDS to manage the master user password in Secrets Manager. Cannot be set if master_password is provided"
+}
+
+variable "admin_user_secret_kms_key_id" {
+  type = string
+  default = null
+  description = "Amazon Web Services KMS key identifier is the key ARN, key ID, alias ARN, or alias name for the KMS key. To use a KMS key in a different Amazon Web Services account, specify the key ARN or alias ARN. If not specified, the default KMS key for your Amazon Web Services account is used"
+}
+
 variable "admin_user" {
   type        = string
   default     = "admin"


### PR DESCRIPTION
## what

Allow to manage master credentials in Secrets Manager

## why

Managed secrets are more secure and easy to use.

## references

(closes #166)
