### PR TITLE
Pass var.db_port to RDS cluster instances

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -102,6 +102,7 @@ resource "aws_rds_cluster" "primary" {
   iam_roles                           = var.iam_roles
   backtrack_window                    = var.backtrack_window
   enable_http_endpoint                = local.is_serverless && var.enable_http_endpoint
+  port                                = var.db_port
   enable_global_write_forwarding      = var.enable_global_write_forwarding
 
   depends_on = [
@@ -197,6 +198,7 @@ resource "aws_rds_cluster" "secondary" {
   iam_roles                           = var.iam_roles
   backtrack_window                    = var.backtrack_window
   enable_http_endpoint                = local.is_serverless && var.enable_http_endpoint
+  port                                = var.db_port
 
   depends_on = [
     aws_db_subnet_group.default,


### PR DESCRIPTION
## what

Currently, the `var.db_port` variable is not passed to both `aws_rds_cluster` resources.  

## why

`var.db_port` is passed to the security group but not the cluster instances, this results to the following cases: 

1. setting `var.db_port` to a value other than the default makes the cluster inaccessible .
2. No way to expose the RDS cluster on a different port

## references

- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster.html#port
- closes #120
