### PR TITLE
fix: Too long identifier name error

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -268,9 +268,28 @@ resource "random_pet" "instance" {
   }
 }
 
+module "rds_identifier" {
+  count  = local.enabled ? 1 : 0
+
+  source  = "cloudposse/label/null"
+  version = "0.25.0"
+
+  name = random_pet.instance[0].id
+  # Max length of RDS identifier is 63 characters, but in `aws_rds_cluster_instance`
+  # we append the instance index to the identifier
+  # Setting the limit to 60 allow to use up to 99 instances, when only 16 is allowed
+  # (1 writer + 15 readers)
+  # https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Aurora.Replication.html
+  id_length_limit = 60
+}
+
+output "cropped_id" {
+  value = module.rds_identifier[0].id
+}
+
 resource "aws_rds_cluster_instance" "default" {
   count                                 = local.cluster_instance_count
-  identifier                            = "${random_pet.instance[0].id}-${count.index + 1}"
+  identifier                            = "${module.rds_identifier[0].id}-${count.index + 1}"
   cluster_identifier                    = coalesce(join("", aws_rds_cluster.primary[*].id), join("", aws_rds_cluster.secondary[*].id))
   instance_class                        = random_pet.instance[0].keepers.instance_class
   db_subnet_group_name                  = join("", aws_db_subnet_group.default[*].name)

--- a/main.tf
+++ b/main.tf
@@ -283,10 +283,6 @@ module "rds_identifier" {
   id_length_limit = 60
 }
 
-output "cropped_id" {
-  value = module.rds_identifier[0].id
-}
-
 resource "aws_rds_cluster_instance" "default" {
   count                                 = local.cluster_instance_count
   identifier                            = "${module.rds_identifier[0].id}-${count.index + 1}"

--- a/main.tf
+++ b/main.tf
@@ -269,7 +269,7 @@ resource "random_pet" "instance" {
 }
 
 module "rds_identifier" {
-  count  = local.enabled ? 1 : 0
+  count = local.enabled ? 1 : 0
 
   source  = "cloudposse/label/null"
   version = "0.25.0"


### PR DESCRIPTION
## what

Fix too long identifier name without cluster recreation:

set `id_length_limit = 40` for

```tf
module "aurora" {
  source  = "cloudposse/rds-cluster/aws"
  version = "1.10.0"
  ...
  id_length_limit = 40
}
``` 
will cause such recreation if final `module.this.id` will be between 40-60 characters

## why

https://github.com/cloudposse/terraform-aws-rds-cluster/releases/tag/1.10.0 introduced `random_pet`, which adds 2 extra words on the top of `module.this.id`, and that exceed limit of 63 allowed characters for RDS names

```tf
╷
│ Error: creating RDS Cluster (company-staging-aurora-payments-ledger-service-aliases) Instance (company-staging-aurora-payments-ledger-service-aliases-promoted-piglet-1): operation error RDS: CreateDBInstance, https response error StatusCode: 400, RequestID: 1979b42f-b1df-4e00-b0ec-d3b629b3002d, api error InvalidParameterValue: Invalid database identifier:  company-staging-aurora-payments-ledger-service-aliases-promoted-piglet-1
│ 
│   with module.aurora_aliases.aws_rds_cluster_instance.default[0],
│   on .terraform/modules/aurora_aliases/main.tf line 261, in resource "aws_rds_cluster_instance" "default":
│  261: resource "aws_rds_cluster_instance" "default" {
```

This PR limit final identifier to 62-63 chars (depends on count of replica)

## references

Fixing https://github.com/cloudposse/terraform-aws-rds-cluster/pull/213
