### PR TITLE
Only set db_cluster_instance_class on the secondary cluster when local.is_serverless is false

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -186,6 +186,7 @@ resource "aws_rds_cluster" "secondary" {
   final_snapshot_identifier           = var.cluster_identifier == "" ? lower(module.this.id) : lower(var.cluster_identifier)
   skip_final_snapshot                 = var.skip_final_snapshot
   apply_immediately                   = var.apply_immediately
+  db_cluster_instance_class           = local.is_serverless ? null : var.db_cluster_instance_class
   storage_encrypted                   = var.storage_encrypted
   storage_type                        = var.storage_type
   kms_key_id                          = var.kms_key_arn


### PR DESCRIPTION
## what

Only set `db_cluster_instance_class` to non-null on the secondary cluster when `local.is_serverless=false`.

## why

The missing `serverlessv2_scaling_configuration` on the secondary cluster was added in #181. The argument `db_cluster_instance_class` should also be aligned with the primary cluster.
