### PR TITLE
output instance endpoints, add attributes to random_pet that force a …

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -313,8 +313,11 @@ resource "random_pet" "instance" {
   count  = local.enabled ? 1 : 0
   prefix = var.cluster_identifier == "" ? module.this.id : var.cluster_identifier
   keepers = {
-    cluster_family = var.cluster_family
-    instance_class = var.serverlessv2_scaling_configuration != null ? "db.serverless" : var.instance_type
+    cluster_family       = var.cluster_family
+    cluster_identifier   = coalesce(join("", aws_rds_cluster.primary[*].id), join("", aws_rds_cluster.secondary[*].id))
+    db_subnet_group_name = join("", aws_db_subnet_group.default[*].name)
+    engine               = var.engine
+    instance_class       = var.serverlessv2_scaling_configuration != null ? "db.serverless" : var.instance_type
   }
 }
 
@@ -336,13 +339,13 @@ module "rds_identifier" {
 resource "aws_rds_cluster_instance" "default" {
   count                                 = local.cluster_instance_count
   identifier                            = "${module.rds_identifier[0].id}-${count.index + 1}"
-  cluster_identifier                    = coalesce(join("", aws_rds_cluster.primary[*].id), join("", aws_rds_cluster.secondary[*].id))
+  cluster_identifier                    = random_pet.instance[0].keepers.cluster_identifier
   instance_class                        = random_pet.instance[0].keepers.instance_class
-  db_subnet_group_name                  = join("", aws_db_subnet_group.default[*].name)
+  db_subnet_group_name                  = random_pet.instance[0].keepers.db_subnet_group_name
   db_parameter_group_name               = join("", aws_db_parameter_group.default[*].name)
   publicly_accessible                   = var.publicly_accessible
   tags                                  = module.this.tags
-  engine                                = var.engine
+  engine                                = random_pet.instance[0].keepers.engine
   engine_version                        = var.engine_version
   auto_minor_version_upgrade            = var.auto_minor_version_upgrade
   monitoring_interval                   = var.rds_monitoring_interval
@@ -371,7 +374,6 @@ resource "aws_rds_cluster_instance" "default" {
     aws_iam_role.enhanced_monitoring,
     aws_rds_cluster.secondary,
     aws_rds_cluster_parameter_group.default,
-    aws_rds_cluster_instance.default[0],
   ]
 
   lifecycle {

--- a/outputs.tf
+++ b/outputs.tf
@@ -44,6 +44,11 @@ output "dbi_resource_ids" {
   description = "List of the region-unique, immutable identifiers for the DB instances in the cluster"
 }
 
+output "instance_endpoints" {
+  value       = aws_rds_cluster_instance.default[*].endpoint
+  description = "List of DNS addresses for the DB instances in the cluster"
+}
+
 output "cluster_resource_id" {
   value       = local.is_regional_cluster ? join("", aws_rds_cluster.primary[*].cluster_resource_id) : join("", aws_rds_cluster.secondary[*].cluster_resource_id)
   description = "The region-unique, immutable identifie of the cluster"


### PR DESCRIPTION
…new instance

## what

- output instance endpoints
- add aws_rds_cluster_instance attributes that force a new instance to the randmon_pet resource.

## why

- I need the actual instance endpoints for the Datadog DMS integration, the default dashboards work better with the exact instance identifier.
- Currently if any of these attributes change (db_subnet_group_name, engine) it will bypass the random_pet and attempt to create instances with the same identifier.

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
