### PR TITLE
fix: reserved instance output

### DIFF
--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -173,6 +173,7 @@
 | <a name="output_database_name"></a> [database\_name](#output\_database\_name) | Database name |
 | <a name="output_dbi_resource_ids"></a> [dbi\_resource\_ids](#output\_dbi\_resource\_ids) | List of the region-unique, immutable identifiers for the DB instances in the cluster |
 | <a name="output_endpoint"></a> [endpoint](#output\_endpoint) | The DNS address of the RDS instance |
+| <a name="output_instance_endpoints"></a> [instance\_endpoints](#output\_instance\_endpoints) | List of DNS addresses for the DB instances in the cluster |
 | <a name="output_master_host"></a> [master\_host](#output\_master\_host) | DB Master hostname |
 | <a name="output_master_username"></a> [master\_username](#output\_master\_username) | Username for the master DB user |
 | <a name="output_reader_endpoint"></a> [reader\_endpoint](#output\_reader\_endpoint) | A read-only endpoint for the Aurora cluster, automatically load-balanced across replicas |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -173,7 +173,6 @@
 | <a name="output_database_name"></a> [database\_name](#output\_database\_name) | Database name |
 | <a name="output_dbi_resource_ids"></a> [dbi\_resource\_ids](#output\_dbi\_resource\_ids) | List of the region-unique, immutable identifiers for the DB instances in the cluster |
 | <a name="output_endpoint"></a> [endpoint](#output\_endpoint) | The DNS address of the RDS instance |
-| <a name="output_instance_endpoints"></a> [instance\_endpoints](#output\_instance\_endpoints) | List of DNS addresses for the DB instances in the cluster |
 | <a name="output_master_host"></a> [master\_host](#output\_master\_host) | DB Master hostname |
 | <a name="output_master_username"></a> [master\_username](#output\_master\_username) | Username for the master DB user |
 | <a name="output_reader_endpoint"></a> [reader\_endpoint](#output\_reader\_endpoint) | A read-only endpoint for the Aurora cluster, automatically load-balanced across replicas |

--- a/outputs.tf
+++ b/outputs.tf
@@ -85,6 +85,6 @@ output "activity_stream_name" {
 }
 
 output "reserved_instance" {
-  value       = join("", aws_rds_reserved_instance.default[*])
+  value       = aws_rds_reserved_instance.default
   description = "All information about the reserved instance(s) if created."
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -85,6 +85,6 @@ output "activity_stream_name" {
 }
 
 output "reserved_instance" {
-  value       = aws_rds_reserved_instance.default[*]
+  value       = aws_rds_reserved_instance.default
   description = "All information about the reserved instance(s) if created."
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -85,6 +85,6 @@ output "activity_stream_name" {
 }
 
 output "reserved_instance" {
-  value       = aws_rds_reserved_instance.default
+  value       = aws_rds_reserved_instance.default[*]
   description = "All information about the reserved instance(s) if created."
 }


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

Fix the output
![image](https://github.com/user-attachments/assets/ea8ef48d-be0f-4e3c-bc10-d39e7c738bf8)


How it will look with this:
![image](https://github.com/user-attachments/assets/88128b40-c9d0-47fe-9902-bd91b9de3990)

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->
It does not need to be a join with a [*] this will cause error, just referring to it with the resource name will output everything as one object. 


## references
See the Terraform provider docs https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_reserved_instance#attribute-reference
<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
