### PR TITLE
fix: reserved instances restrictions

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -14,7 +14,7 @@ locals {
   enable_http_endpoint     = var.enable_http_endpoint && (local.is_serverless || local.is_serverless_v2)
   ignore_admin_credentials = var.replication_source_identifier != "" || var.snapshot_identifier != null
   reserved_instance_engine = var.engine
-  use_reserved_instances   = var.use_reserved_instances && !local.is_serverless && contains(["mysql", "postgresql"], local.reserved_instance_engine)
+  use_reserved_instances   = var.use_reserved_instances && !local.is_serverless
 }
 
 data "aws_partition" "current" {


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

This conditional check on whether or not to enable reserved instances is too restrictive. `contains(["mysql", "postgresql"], local.reserved_instance_engine)` is saying that only allow it if it is MySQL or PostgreSQL.

I think `contains` was originally meant to be like in the literal sense of "contains". Since in my case, I'm using `aurora-postgresql`, and it fails this check, yet it is one of the options for reserved instances.


## why
`endswith` might be better, but it is TOO restrictive, seeing that there's so many options.
![image](https://github.com/user-attachments/assets/7bea9fad-c00f-49ca-94fd-f47f379c12e3)
Additionally, Terraform will fail if user specifies the wrong engine type. There's no need for this check.

![image](https://github.com/user-attachments/assets/7ffd6e19-2cda-421b-ae6e-eb0511a089af)


<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->

https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/rds_reserved_instance_offering