### PR TITLE
Allow instance_class configuration even if serverless scaling config …

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -5,7 +5,7 @@ locals {
 
   deployed_cluster_identifier = local.enabled ? coalesce(one(aws_rds_cluster.primary[*].id), one(aws_rds_cluster.secondary[*].id)) : ""
   db_subnet_group_name        = one(aws_db_subnet_group.default[*].name)
-  instance_class              = var.serverlessv2_scaling_configuration != null ? "db.serverless" : var.instance_type
+  instance_class              = var.instance_type
 
   cluster_instance_count   = local.enabled ? var.cluster_size : 0
   is_regional_cluster      = var.cluster_type == "regional"

--- a/variables.tf
+++ b/variables.tf
@@ -27,7 +27,7 @@ variable "subnets" {
 variable "instance_type" {
   type        = string
   default     = "db.t2.small"
-  description = "Instance type to use"
+  description = "Instance type to use.  Use db.serverless for serverlessv2"
 }
 
 variable "cluster_identifier" {


### PR DESCRIPTION
…exists

## what

- Don't override instance class based on serverlessv2 scaling configuration

## why

- serverlessv2 scaling configuration is a cluster attribute; it doesn't preclude provisioning provisioned instances in provisioned clusters

## references
- closes #246
- helps cope with #168
