### PR TITLE
fix: reserved instance multi_az setting

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -100,7 +100,7 @@ data "aws_rds_reserved_instance_offering" "default" {
   count               = local.use_reserved_instances ? 1 : 0
   db_instance_class   = var.instance_type
   duration            = var.rds_ri_duration
-  multi_az            = local.is_regional_cluster
+  multi_az            = local.cluster_instance_count > 1
   offering_type       = var.rds_ri_offering_type
   product_description = local.reserved_instance_engine
 }


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

Using `local.is_regional_cluster` to determine whether or not it is Multi-AZ is not accurate. local.is_regional_cluster only checks if var.cluster_type == "regional", which determines if this is a regional vs global cluster

I could have a regional cluster, but it is NOT multi-az. One determining factor is how many instances in the cluster, if ever more than 1 in a single cluster, then it has to be in multiple AZs. https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.MultiAZ.html

![image](https://github.com/user-attachments/assets/a1654275-2d90-4281-ad2b-d9df975800de)



## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->
If I have a regional cluster, this thinks that it's ALWAYS multi-az, which is not true. 

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->

https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.MultiAZ.html
