### PR TITLE
fix: reserved instances, aurora rds specifics

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -100,7 +100,7 @@ data "aws_rds_reserved_instance_offering" "default" {
   count               = local.use_reserved_instances ? 1 : 0
   db_instance_class   = var.instance_type
   duration            = var.rds_ri_duration
-  multi_az           = startswith(local.reserved_instance_engine, "aurora") ? false : local.cluster_instance_count > 1 # Aurora options never available for multi AZ for Reserved Instances. Single Reserved Instances rates still apply. https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/USER_WorkingWithReservedDBInstances.html
+  multi_az            = startswith(local.reserved_instance_engine, "aurora") ? false : local.cluster_instance_count > 1 # Aurora options never available for multi AZ for Reserved Instances. Single Reserved Instances rates still apply. https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/USER_WorkingWithReservedDBInstances.html
   offering_type       = var.rds_ri_offering_type
   product_description = local.reserved_instance_engine
 }

--- a/main.tf
+++ b/main.tf
@@ -100,7 +100,7 @@ data "aws_rds_reserved_instance_offering" "default" {
   count               = local.use_reserved_instances ? 1 : 0
   db_instance_class   = var.instance_type
   duration            = var.rds_ri_duration
-  multi_az            = local.cluster_instance_count > 1
+  multi_az           = startswith(local.reserved_instance_engine, "aurora") ? false : local.cluster_instance_count > 1 # Aurora options never available for multi AZ for Reserved Instances. Single Reserved Instances rates still apply. https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/USER_WorkingWithReservedDBInstances.html
   offering_type       = var.rds_ri_offering_type
   product_description = local.reserved_instance_engine
 }


### PR DESCRIPTION
## what
RDS Reserved Instances multi AZ mode is never available for Aurora engines, see images on the console - this PR checks to ensure that it is set to false if the engine is Aurora:
![image](https://github.com/user-attachments/assets/58a2ebb4-400a-41ba-8b07-1560700d16a1)
![image](https://github.com/user-attachments/assets/66bdf1df-1a22-4757-91fc-cd91e540a2bf)


<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

## why
That configuration isn't really applicable anyways since this statement from the AWS docs https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/USER_WorkingWithReservedDBInstances.html:
![image](https://github.com/user-attachments/assets/b26c4c0b-5861-4206-8ed3-d701aac31b78)

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

## references
https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/USER_WorkingWithReservedDBInstances.html
<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
