### PR TITLE
feat: adds seconds_until_auto_pause argument

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -200,7 +200,7 @@ resource "aws_rds_cluster" "primary" {
     content {
       max_capacity             = serverlessv2_scaling_configuration.value.max_capacity
       min_capacity             = serverlessv2_scaling_configuration.value.min_capacity
-      seconds_until_auto_pause = lookup(serverlessv2_scaling_configuration.value, "seconds_until_auto_pause", null)
+      seconds_until_auto_pause = serverlessv2_scaling_configuration.value.seconds_until_auto_pause
     }
   }
 

--- a/main.tf
+++ b/main.tf
@@ -198,8 +198,9 @@ resource "aws_rds_cluster" "primary" {
   dynamic "serverlessv2_scaling_configuration" {
     for_each = var.serverlessv2_scaling_configuration[*]
     content {
-      max_capacity = serverlessv2_scaling_configuration.value.max_capacity
-      min_capacity = serverlessv2_scaling_configuration.value.min_capacity
+      max_capacity             = serverlessv2_scaling_configuration.value.max_capacity
+      min_capacity             = serverlessv2_scaling_configuration.value.min_capacity
+      seconds_until_auto_pause = lookup(serverlessv2_scaling_configuration.value, "seconds_until_auto_pause", null)
     }
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -213,8 +213,9 @@ variable "scaling_configuration" {
 
 variable "serverlessv2_scaling_configuration" {
   type = object({
-    min_capacity = number
-    max_capacity = number
+    min_capacity             = number
+    max_capacity             = number
+    seconds_until_auto_pause = optional(number, null)
   })
   default     = null
   description = "serverlessv2 scaling properties"

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.61.0"
+      version = ">= 5.81.0"
     }
     null = {
       source  = "hashicorp/null"


### PR DESCRIPTION
## what

- Adds the `seconds_until_auto_pause` argument for `serverlessv2_scaling_configuration`

## why

- Allow users to set this value to autopause clusters as needed

## references

- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster#serverlessv2_scaling_configuration-argument-reference
- https://github.com/hashicorp/terraform-provider-aws/releases/tag/v5.81.0
- closes #238
