### PR TITLE
feat(security-groups): add ingress prefix lists

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -72,6 +72,17 @@ resource "aws_security_group_rule" "ingress_ipv6_cidr_blocks" {
   security_group_id = join("", aws_security_group.default[*].id)
 }
 
+resource "aws_security_group_rule" "ingress_prefix_lists" {
+  count             = local.enabled && length(var.allowed_prefix_list_ids) > 0 ? 1 : 0
+  description       = "Allow inbound traffic from prefix lists"
+  type              = "ingress"
+  from_port         = var.db_port
+  to_port           = var.db_port
+  protocol          = "tcp"
+  prefix_list_ids   = var.allowed_prefix_list_ids
+  security_group_id = one(aws_security_group.default[*].id)
+}
+
 resource "aws_security_group_rule" "egress" {
   count             = local.enabled && var.egress_enabled ? 1 : 0
   description       = "Allow outbound traffic"

--- a/variables.tf
+++ b/variables.tf
@@ -265,6 +265,12 @@ variable "allowed_ipv6_cidr_blocks" {
   description = "List of IPv6 CIDR blocks allowed to access the cluster"
 }
 
+variable "allowed_prefix_list_ids" {
+  type        = list(string)
+  default     = []
+  description = "List of prefix list IDs allowed to access the cluster"
+}
+
 variable "publicly_accessible" {
   type        = bool
   description = "Set to true if you want your cluster to be publicly accessible (such as via QuickSight)"


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

- Allow using prefix lists for allowing ingress traffic using.
- New variable: `allowed_prefix_list_ids`
- New resource: `aws_security_group_rule.ingress_cidr_blocks`

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

- Improve visibility, manageability and reusability when using prefix lists for repeating CIDR blocks instead of duplicating these CIDR blocks for each RDS module call.

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->

- https://docs.aws.amazon.com/vpc/latest/userguide/working-with-aws-managed-prefix-lists.html
