### PR TITLE
fix: ignore global_cluster_identifier drift on primary and secondary clusters

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -227,6 +227,10 @@ resource "aws_rds_cluster" "primary" {
   enabled_cloudwatch_logs_exports = var.enabled_cloudwatch_logs_exports
   deletion_protection             = var.deletion_protection
   replication_source_identifier   = var.replication_source_identifier
+
+  lifecycle {
+    ignore_changes = [global_cluster_identifier]
+  }
 }
 
 # https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster#replication_source_identifier

--- a/main.tf
+++ b/main.tf
@@ -321,6 +321,7 @@ resource "aws_rds_cluster" "secondary" {
 
   lifecycle {
     ignore_changes = [
+      global_cluster_identifier,     # AWS provider does not read this back from the API
       replication_source_identifier, # will be set/managed by Global Cluster
       snapshot_identifier,           # if created from a snapshot, will be non-null at creation, but null afterwards
     ]


### PR DESCRIPTION
## what

- Add `lifecycle { ignore_changes = [global_cluster_identifier] }` to both `aws_rds_cluster.primary` and `aws_rds_cluster.secondary`

## why

- The AWS provider Read function does not populate `global_cluster_identifier` from the DescribeDBClusters API
- On `primary`: `terraform plan` shows `global_cluster_identifier -> null`, and applying destructively removes the cluster from the global database
- On `secondary`: any `terraform apply` that modifies other attributes (tags, parameters, monitoring) also detaches the cluster from the global database, because the provider sends `global_cluster_identifier = null` during the update
- `aws_rds_cluster.secondary` already protects against similar drift for `replication_source_identifier` — this adds the same protection for `global_cluster_identifier`

## references

- closes #281