### PR TITLE
feat(outputs): expose instance ARNs

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -60,6 +60,11 @@ output "instance_endpoints" {
   description = "List of DNS addresses for the DB instances in the cluster"
 }
 
+output "instance_arns" {
+  value       = aws_rds_cluster_instance.default[*].arn
+  description = "List of ARNs of the DB instances in the cluster"
+}
+
 output "cluster_resource_id" {
   value       = local.is_regional_cluster ? join("", aws_rds_cluster.primary[*].cluster_resource_id) : join("", aws_rds_cluster.secondary[*].cluster_resource_id)
   description = "The region-unique, immutable identifie of the cluster"


### PR DESCRIPTION
## What

Add `instance_arns` output exposing `aws_rds_cluster_instance.default[*].arn`.

### Why

Consumers wrapping this module need per-instance ARNs (e.g. for AWS Backup
selection, IAM resource policies, tagging). Currently there is no way to get
them from the module — the only workaround is an `aws_db_instances` data
source hack outside the module, which adds an extra API call, requires
`depends_on`, and has timing edge-cases.

The resource is already present; this just exposes it alongside the existing
`instance_endpoints` and `dbi_resource_ids` outputs, following the same pattern.

And I don't want to introduce 

```tf
data "aws_db_instances" "aurora_instances" {
  depends_on = [module.aurora]

  filter {
    name   = "db-cluster-id"
    values = [module.aurora.cluster_identifier]
  }
}
```


---
_Generated by Sisyphus:claude-sonnet-4-6 opencode_