### PR TITLE
feature: Add support to associate IAM role with feature name to RDS cluster.

### DIFF
--- a/README.yaml
+++ b/README.yaml
@@ -278,6 +278,26 @@ usage: |2-
   }
   ```
 
+  ### Managing IAM roles on the cluster
+
+  The module exposes two variables for attaching IAM roles to the Aurora cluster:
+
+  - `var.iam_roles` — a list of role ARNs attached to the cluster without a `feature_name`.
+    Retained for backwards compatibility. **Post-create drift on this variable is ignored** —
+    after the cluster is created, editing this variable produces no plan diff, no error, and
+    no AWS API call.
+
+  - `var.role_associations` — a map of role ARNs (with optional `feature_name`) that maps to
+    `aws_rds_cluster_role_association` resources inside the module. This is the preferred path
+    for attaching roles that require a `feature_name` such as `s3Export`, `s3Import`, or
+    `Lambda`, and it fully reconciles additions and removals after cluster creation.
+
+  Do NOT place the same `role_arn` in both variables — the AWS `AddRoleToDBCluster` API may
+  reject the second call with `DBClusterRoleAlreadyExists`, causing apply to fail.
+
+  See [examples/with_iam_role_associations](examples/with_iam_role_associations) for a full
+  working example.
+
 examples: |-
   Review the [complete example](examples/complete) to see how to use this module.
 

--- a/README.yaml
+++ b/README.yaml
@@ -295,9 +295,6 @@ usage: |2-
   Do NOT place the same `role_arn` in both variables — the AWS `AddRoleToDBCluster` API may
   reject the second call with `DBClusterRoleAlreadyExists`, causing apply to fail.
 
-  See [examples/with_iam_role_associations](examples/with_iam_role_associations) for a full
-  working example.
-
 examples: |-
   Review the [complete example](examples/complete) to see how to use this module.
 

--- a/main.tf
+++ b/main.tf
@@ -234,6 +234,12 @@ resource "aws_rds_cluster" "primary" {
   enabled_cloudwatch_logs_exports = var.enabled_cloudwatch_logs_exports
   deletion_protection             = var.deletion_protection
   replication_source_identifier   = var.replication_source_identifier
+
+  lifecycle {
+    ignore_changes = [
+      iam_roles, # managed via aws_rds_cluster_role_association; ignoring drift prevents DBClusterRoleNotFound conflicts
+    ]
+  }
 }
 
 # https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster#replication_source_identifier
@@ -326,8 +332,17 @@ resource "aws_rds_cluster" "secondary" {
     ignore_changes = [
       replication_source_identifier, # will be set/managed by Global Cluster
       snapshot_identifier,           # if created from a snapshot, will be non-null at creation, but null afterwards
+      iam_roles,                     # managed via aws_rds_cluster_role_association; ignoring drift prevents DBClusterRoleNotFound conflicts
     ]
   }
+}
+
+resource "aws_rds_cluster_role_association" "this" {
+  for_each = local.enabled ? var.role_associations : {}
+
+  db_cluster_identifier = local.is_regional_cluster ? join("", aws_rds_cluster.primary[*].id) : join("", aws_rds_cluster.secondary[*].id)
+  feature_name          = try(coalesce(each.value.feature_name, each.key), null)
+  role_arn              = each.value.role_arn
 }
 
 resource "random_pet" "instance" {

--- a/variables.tf
+++ b/variables.tf
@@ -499,15 +499,7 @@ variable "source_region" {
 
 variable "iam_roles" {
   type        = list(string)
-  description = <<-EOT
-    IAM role ARNs to associate with the Aurora cluster at creation time (without a `feature_name`).
-    Behavior warning: after the initial cluster creation, edits to this variable have NO effect —
-    Terraform ignores post-create drift on this attribute to prevent conflicts with
-    `aws_rds_cluster_role_association`. Adding or removing an ARN here after the cluster exists
-    produces no plan diff, no error, and no AWS API call.
-    To manage roles after creation, or to attach a role with a specific `feature_name`
-    (e.g. `s3Export`, `s3Import`, `Lambda`), use `var.role_associations` instead.
-  EOT
+  description = "Iam roles for the Aurora cluster"
   default     = []
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -499,8 +499,36 @@ variable "source_region" {
 
 variable "iam_roles" {
   type        = list(string)
-  description = "Iam roles for the Aurora cluster"
+  description = <<-EOT
+    IAM role ARNs to associate with the Aurora cluster at creation time (without a `feature_name`).
+    Behavior warning: after the initial cluster creation, edits to this variable have NO effect —
+    Terraform ignores post-create drift on this attribute to prevent conflicts with
+    `aws_rds_cluster_role_association`. Adding or removing an ARN here after the cluster exists
+    produces no plan diff, no error, and no AWS API call.
+    To manage roles after creation, or to attach a role with a specific `feature_name`
+    (e.g. `s3Export`, `s3Import`, `Lambda`), use `var.role_associations` instead.
+  EOT
   default     = []
+}
+
+variable "role_associations" {
+  type = map(object({
+    feature_name = optional(string)
+    role_arn     = string
+  }))
+  description = <<-EOT
+    Map of IAM role ARNs and their supported feature names to associate with the cluster via
+    `aws_rds_cluster_role_association`. The map key is used as the `feature_name` when the
+    `feature_name` field is omitted. Supported feature names include `s3Export`, `s3Import`,
+    and `Lambda` (see AWS RDS docs for the full list).
+
+    Do NOT place the same `role_arn` in both `var.iam_roles` and `var.role_associations` —
+    the AWS `AddRoleToDBCluster` API may reject the second call with
+    `DBClusterRoleAlreadyExists`, causing apply to fail. Prefer `role_associations` for new
+    consumers; it supports per-role `feature_name` values that `var.iam_roles` cannot express.
+  EOT
+  default     = {}
+  nullable    = false
 }
 
 variable "backtrack_window" {


### PR DESCRIPTION
## what

* Add a new `var.role_associations` variable (`map(object({ feature_name = optional(string), role_arn = string }))`) backed by an internal `aws_rds_cluster_role_association.this` resource.
* Add `iam_roles` to `lifecycle.ignore_changes` on both `aws_rds_cluster.primary` and `aws_rds_cluster.secondary`.
* Strengthen the description of `var.iam_roles` with an explicit silent-mutation-after-create warning.
* Add a "Managing IAM roles on the cluster" narrative section to `README.yaml`.

## why

Consumers who need to attach IAM roles with a `feature_name` (e.g. `s3Export`, `s3Import`, `Lambda`) currently have to manage the association themselves via a separate `aws_rds_cluster_role_association` resource, because `var.iam_roles` on this module maps directly to `aws_rds_cluster.iam_roles`, which does **not** support `feature_name`.

The AWS provider docs explicitly warn against mixing the two management styles:

> Use one resource or the other. Not doing so will cause a conflict.
> — [`aws_rds_cluster` docs, `iam_roles` argument](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster#iam_roles)

When both are used, on the next `terraform plan` the provider refreshes real `DBClusterRoles` back into state, then plans to remove them via `RemoveRoleFromDBCluster` **without** `--feature-name`. AWS returns 404 because the roles are registered under `FeatureName=s3Export`/`s3Import`:

```
Error: removing IAM Role (arn:aws:iam::…:role/…-rds-s3-export) from RDS Cluster (…):
DBClusterRoleNotFound: You might need to include the feature-name parameter.
```

This PR fixes both sides of the problem:

1. **`ignore_changes = [iam_roles]`** disables the broken removal path — the `DBClusterRoleNotFound` 404 goes away.
2. **`role_associations`** gives consumers a first-class, in-module way to attach `feature_name`-aware roles without needing to bolt on their own `aws_rds_cluster_role_association` resource.

## behavior notes

* **`var.iam_roles` is retained** for backwards compatibility. Consumers already using it see no immediate change beyond drift no longer being reconciled.
* **After the initial apply, edits to `var.iam_roles` have no effect** — no plan diff, no error, no AWS API call. To manage roles post-create, use `var.role_associations`. This is documented on the variable itself and in the README.
* **Do NOT place the same `role_arn` in both `var.iam_roles` and `var.role_associations`.** The AWS `AddRoleToDBCluster` API may reject the second call with `DBClusterRoleAlreadyExists`, causing apply to fail. Documented in the `role_associations` variable description and the README.

## references

* Reproduction — internal cluster `dwt-uat-use1-data-tbs-tbs`; error text above.
* AWS provider docs — [`aws_rds_cluster` — `iam_roles`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster#iam_roles).
* AWS provider docs — [`aws_rds_cluster_role_association`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster_role_association).
* Prior art — [`terraform-aws-modules/terraform-aws-rds-aurora` `main.tf`](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/blob/master/main.tf) removes `iam_roles` from `aws_rds_cluster` entirely and manages associations via `aws_rds_cluster_role_association`. This PR follows the same pattern, but keeps `var.iam_roles` in place (drift-ignored) rather than dropping it, to remain non-breaking.